### PR TITLE
Configure https

### DIFF
--- a/aws-prod.config
+++ b/aws-prod.config
@@ -5,6 +5,7 @@ tablename="scrum_poker"
 # constants: DO NOT CHANGE!
 basedomainname="playground.aws.tngtech.com"
 certificate="arn:aws:acm:eu-central-1:530798195059:certificate/9fb19f73-7147-4e1b-afeb-beb88568d5d5"
+cloudfrontcertificate="arn:aws:acm:us-east-1:530798195059:certificate/2b9035b3-616b-41c7-8ab3-f71135b2fd60"
 
 # auto generated variables
 S3Backend=${subdomainname}

--- a/aws-prod.config
+++ b/aws-prod.config
@@ -5,7 +5,7 @@ tablename="scrum_poker"
 # constants: DO NOT CHANGE!
 basedomainname="playground.aws.tngtech.com"
 certificate="arn:aws:acm:eu-central-1:530798195059:certificate/9fb19f73-7147-4e1b-afeb-beb88568d5d5"
-cloudfrontcertificate="arn:aws:acm:us-east-1:530798195059:certificate/2b9035b3-616b-41c7-8ab3-f71135b2fd60"
+cloudfrontcertificate="arn:aws:acm:us-east-1:530798195059:certificate/6b40146a-bde5-403e-9686-5ee73749bb2b"
 
 # auto generated variables
 S3Backend=${subdomainname}

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -23,9 +23,6 @@ Parameters:
     Type: String
   S3Frontend:
     Type: String
-  S3DNSName:
-    Type: String
-    Default: 's3-website.eu-central-1.amazonaws.com'
   ExpiryTimeInHour:
     Type: Number
     Default: 15

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -19,9 +19,16 @@ Parameters:
     Type: String
   CertificateArn:
     Type: String
+  CloudFrontCertificate:
+    Type: String
+  S3Frontend:
+    Type: String
   S3HostedZoneId:
     Type: String
     Default: 'Z21DNDUVLTQW6Q'
+  CloudFrontHostedZoneId:
+    Type: String
+    Default: 'Z2FDTNDATAQYW2'
   S3DNSName:
     Type: String
     Default: 's3-website.eu-central-1.amazonaws.com'
@@ -207,6 +214,29 @@ Resources:
       DomainNameConfigurations:
         - EndpointType: REGIONAL
           CertificateArn: !Ref CertificateArn
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Origins:
+          - DomainName: !Sub '${S3Frontend}.s3.amazonaws.com'
+            Id: !Sub 'S3-${SubDomain}.${BaseDomain}'
+            S3OriginConfig:
+              OriginAccessIdentity: ''
+        Aliases:
+          - !Sub '${SubDomain}.${BaseDomain}'
+        Enabled: 'true'
+        DefaultRootObject: 'index.html'
+        DefaultCacheBehavior:
+          TargetOriginId: !Sub 'S3-${SubDomain}.${BaseDomain}'
+          ForwardedValues:
+            QueryString: 'false'
+            Cookies:
+              Forward: none
+          ViewerProtocolPolicy: redirect-to-https
+        ViewerCertificate:
+          AcmCertificateArn: !Ref CloudFrontCertificate
+          SslSupportMethod: sni-only
   ApiMapping:
     Type: AWS::ApiGatewayV2::ApiMapping
     DependsOn:
@@ -234,8 +264,8 @@ Resources:
       HostedZoneName: !Sub '${BaseDomain}.'
       Type: A
       AliasTarget:
-        DNSName: !Ref S3DNSName
-        HostedZoneId: !Ref S3HostedZoneId
+        DNSName: !GetAtt CloudFrontDistribution.DomainName
+        HostedZoneId: !Ref CloudFrontHostedZoneId
 
 Outputs:
   ConnectionsTableArn:

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -23,12 +23,6 @@ Parameters:
     Type: String
   S3Frontend:
     Type: String
-  S3HostedZoneId:
-    Type: String
-    Default: 'Z21DNDUVLTQW6Q'
-  CloudFrontHostedZoneId:
-    Type: String
-    Default: 'Z2FDTNDATAQYW2'
   S3DNSName:
     Type: String
     Default: 's3-website.eu-central-1.amazonaws.com'
@@ -265,7 +259,7 @@ Resources:
       Type: A
       AliasTarget:
         DNSName: !GetAtt CloudFrontDistribution.DomainName
-        HostedZoneId: !Ref CloudFrontHostedZoneId
+        HostedZoneId: 'Z2FDTNDATAQYW2'
 
 Outputs:
   ConnectionsTableArn:

--- a/scrumctrl.sh
+++ b/scrumctrl.sh
@@ -31,7 +31,9 @@ deploy(){
       --parameter-overrides TableName=${tablename} \
           BaseDomain=${basedomainname} \
           SubDomain=${subdomainname} \
-          CertificateArn=${certificate}
+          CertificateArn=${certificate} \
+          CloudFrontCertificate=${cloudfrontcertificate} \
+          S3Frontend=${S3Frontend}
 }
 
 delete() {


### PR DESCRIPTION
Use HTTPS by adding CloudFront between the S3 bucket hosting our static website and the DNS service in Route53. Since CloudFront is regionless, but requires a certificate in us-1-east region, a certificate for *.playground.aws.tngtech.com was created and used.