### PR TITLE
Homogenize styling in firefox

### DIFF
--- a/frontend/src/styles.ts
+++ b/frontend/src/styles.ts
@@ -18,6 +18,8 @@ export const buttonStyle = `
   ${BORDER_RADIUS};
   height: ${BUTTON_HEIGHT};
   width: 150px;
+  font: 13.3333px Arial;
+  padding: 1px 6px;
   
   :disabled {
     background: ${TNG_GRAY};


### PR DESCRIPTION
* Chrome and firefox provide different default values for the font and the padding
* The client was clearly developed with Chrome in mind. The aesthetics in Chrome look
nicely, but they are somewhat off in Firefox
* Hence, I took Chrome as a reference and edited the button styles so that the buttons
look alike in Chrome and Firefox
* This immediately fixes the issue where, in Firefox, the text would overflow out of the
button in the buttons "Copy Link to Clipboard" and "Kick users without vote"

Screenshot of the deployed scrum poker:
![image](https://user-images.githubusercontent.com/16071626/101673236-332bb400-3a57-11eb-8497-aae1e03f089d.png)

Screeshot of the dev setup with the changes in this PR:
![image](https://user-images.githubusercontent.com/16071626/101673299-48084780-3a57-11eb-8d2c-5e3cde298551.png)

OS: 5.9.11-3-MANJARO
Browser: Mozilla Firefox 83.0