### PR TITLE
Switch to Preact

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,6 @@
     <title>Next Generation Scrum Poker</title>
   </head>
   <body>
-    <div id="root"></div>
     <script src="build/index.js" type="module"></script>
   </body>
 </html>

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -7,8 +7,6 @@ module.exports = {
   },
   moduleFileExtensions: ['js', 'ts', 'tsx', 'mjs'],
   moduleNameMapper: {
-    // re-map all calls to react(-dom/test-utils) to the aliased CJS versions
-    '^react((-dom(/.*)?)?)$': '<rootDir>/node_modules/test-react$1',
     // There is no CJS version for csz available and we cannot use ESM in node_modules
     '^csz$': '<rootDir>/src/test-utils/csz.js',
     // Remove extensions from imports so that Jest can resolve .js as .ts

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1814,14 +1814,13 @@
         }
       }
     },
-    "@testing-library/react": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.5.tgz",
-      "integrity": "sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==",
+    "@testing-library/preact": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/preact/-/preact-2.0.1.tgz",
+      "integrity": "sha512-79kwVOY+3caoLgaPbiPzikjgY0Aya7Fc7TvGtR1upCnz2wrtmPDnN2t9vO7I7vDP2zoA+feSwOH5Q0BFErhaaQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.28.1"
+        "@testing-library/dom": "^7.16.2"
       }
     },
     "@types/accepts": {
@@ -2235,26 +2234,6 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
     },
-    "@types/react": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
-      "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
-      "dev": true,
-      "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-dom": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.3.tgz",
-      "integrity": "sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/relateurl": {
       "version": "0.2.28",
       "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
@@ -2269,12 +2248,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/scheduler": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
-      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
     },
     "@types/serve-static": {
       "version": "1.13.9",
@@ -6855,15 +6828,6 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
     "lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -7609,6 +7573,11 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "preact": {
+      "version": "10.5.13",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.13.tgz",
+      "integrity": "sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ=="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -8292,16 +8261,6 @@
         "xmlchars": "^2.2.0"
       }
     },
-    "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -8935,27 +8894,6 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
-      }
-    },
-    "test-react": {
-      "version": "npm:react@17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "test-react-dom": {
-      "version": "npm:react-dom@17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
       }
     },
     "thenify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,12 +27,10 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@testing-library/jest-dom": "^5.11.9",
-    "@testing-library/react": "^11.2.5",
+    "@testing-library/preact": "^2.0.1",
     "@types/classnames": "^2.2.11",
     "@types/jest": "^26.0.21",
     "@types/prop-types": "^15.7.3",
-    "@types/react": "^17.0.3",
-    "@types/react-dom": "^17.0.3",
     "csstype": "^3.0.7",
     "es-dev-server": "^2.1.0",
     "es-dev-server-rollup": "0.0.8",
@@ -42,14 +40,13 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.42.4",
     "rollup-plugin-terser": "^7.0.2",
-    "test-react": "npm:react@^17.0.2",
-    "test-react-dom": "npm:react-dom@^17.0.2",
     "ts-jest": "^26.5.4",
     "typescript": "^4.2.3"
   },
   "dependencies": {
     "classnames": "^2.2.6",
     "csz": "^1.2.0",
+    "preact": "^10.5.13",
     "react": "npm:@pika/react@^16.13.1",
     "react-dom": "npm:@pika/react-dom@^16.13.1"
   }

--- a/frontend/src/Components/App.test.tsx
+++ b/frontend/src/Components/App.test.tsx
@@ -1,7 +1,6 @@
-import { act, fireEvent, render } from '@testing-library/react';
-import * as React from 'react';
-import { App } from './App.js';
+import { act, fireEvent, render } from '@testing-library/preact';
 import { COHEN_SCALE } from '../constants';
+import { App } from './App.js';
 
 const ConfigureMockWebSocket = () => {
   const instances: MockWebSocket[] = [];

--- a/frontend/src/Components/App.tsx
+++ b/frontend/src/Components/App.tsx
@@ -1,5 +1,4 @@
 import css from 'csz';
-import * as React from 'react';
 import { PageSelector } from './PageSelector.js';
 import { WebSocketProvider } from './WebSocket.js';
 

--- a/frontend/src/Components/CoffeeIcon.tsx
+++ b/frontend/src/Components/CoffeeIcon.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 // taken from material ui icons
 export const CoffeeIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">

--- a/frontend/src/Components/CopyToClipboardButton.tsx
+++ b/frontend/src/Components/CopyToClipboardButton.tsx
@@ -1,5 +1,4 @@
 import css from 'csz';
-import * as React from 'react';
 import { buttonStyle } from '../styles.js';
 
 const copyToClipboardButtonStyles = css`

--- a/frontend/src/Components/LoginInfo.tsx
+++ b/frontend/src/Components/LoginInfo.tsx
@@ -1,5 +1,4 @@
 import css from 'csz';
-import * as React from 'react';
 import { ASSET_TNG_LOGO } from '../assets.js';
 import { TNG_GRAY } from '../styles.js';
 import { WebSocketApi } from '../types/WebSocket.js';

--- a/frontend/src/Components/LoginPage.tsx
+++ b/frontend/src/Components/LoginPage.tsx
@@ -1,5 +1,6 @@
 import css from 'csz';
-import * as React from 'react';
+import { RefObject } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { ASSET_TNG_LOGO } from '../assets.js';
 import { BORDER_RADIUS, buttonStyle, TNG_BLUE } from '../styles.js';
 import { WebSocketApi } from '../types/WebSocket.js';
@@ -79,15 +80,15 @@ const styling = css`
 `;
 
 const ProtoLoginPage = ({ socket }: { socket: WebSocketApi }) => {
-  const firstInputRef: React.RefObject<HTMLInputElement> = React.useRef(null);
-  const [user, setUser] = React.useState(socket.loginData.user);
+  const firstInputRef: RefObject<HTMLInputElement> = useRef(null);
+  const [user, setUser] = useState(socket.loginData.user);
   let sessionId = new URLSearchParams(window.location.search).get('sessionId') || '';
   if (!sessionId.match(/^[a-zA-Z0-9]{16}$/i)) {
     sessionId = generateId(16);
     history.replaceState({}, 'Scrum Poker', `?sessionId=${sessionId}`);
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (firstInputRef.current) {
       firstInputRef.current.focus();
     }
@@ -115,7 +116,7 @@ const ProtoLoginPage = ({ socket }: { socket: WebSocketApi }) => {
         value={user}
         ref={firstInputRef}
         className="user-input"
-        onChange={(event) => setUser(event.target.value)}
+        onChange={(event) => setUser((event.target as HTMLInputElement).value)}
       />
       <label htmlFor="session" className="session-label">
         Session:

--- a/frontend/src/Components/NotVotedIcon.tsx
+++ b/frontend/src/Components/NotVotedIcon.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 // taken from material ui icons
 export const NotVotedIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">

--- a/frontend/src/Components/ObserverIcon.tsx
+++ b/frontend/src/Components/ObserverIcon.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 // taken from material ui icons
 export const ObserverIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">

--- a/frontend/src/Components/PageSelector.tsx
+++ b/frontend/src/Components/PageSelector.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { WebSocketApi } from '../types/WebSocket.js';
 import { LoginInfo } from './LoginInfo.js';
 import { LoginPage } from './LoginPage.js';

--- a/frontend/src/Components/ResultsPage/ResultsPage.tsx
+++ b/frontend/src/Components/ResultsPage/ResultsPage.tsx
@@ -1,12 +1,11 @@
 import css from 'csz';
-import * as React from 'react';
 import { buttonStyle, headingStyle, tableStyle, TNG_GRAY } from '../../styles.js';
 import { CardValue, Votes, WebSocketApi } from '../../types/WebSocket.js';
-import { connectToWebSocket } from '../WebSocket.js';
-import { compareVotes } from './compareVotes.js';
 import { CoffeeIcon } from '../CoffeeIcon';
 import { NotVotedIcon } from '../NotVotedIcon';
 import { ObserverIcon } from '../ObserverIcon';
+import { connectToWebSocket } from '../WebSocket.js';
+import { compareVotes } from './compareVotes.js';
 
 const styling = css`
   display: flex;

--- a/frontend/src/Components/VotedIcon.tsx
+++ b/frontend/src/Components/VotedIcon.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 // taken from material ui icons
 export const VotedIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">

--- a/frontend/src/Components/VotingPage.tsx
+++ b/frontend/src/Components/VotingPage.tsx
@@ -1,12 +1,11 @@
 import css from 'csz';
-import * as React from 'react';
+import { useEffect, useState } from 'preact/hooks';
+import { SCALE_MAPPING } from '../constants';
 import { buttonStyle, headingStyle, TNG_BLUE, TNG_GRAY } from '../styles.js';
 import { CardValue, WebSocketApi } from '../types/WebSocket.js';
+import { CoffeeIcon } from './CoffeeIcon';
 import { VotingStateDisplay } from './VotingStateDisplay.js';
 import { connectToWebSocket } from './WebSocket.js';
-import { CoffeeIcon } from './CoffeeIcon';
-import { SCALE_MAPPING } from '../constants';
-import { useEffect } from 'react';
 
 const votingPageStyle = css`
   display: flex;
@@ -90,7 +89,7 @@ const votingPageStyle = css`
 `;
 
 const ProtoVotingPage = ({ socket }: { socket: WebSocketApi }) => {
-  const [selectedCard, setSelectedCard] = React.useState<CardValue>(
+  const [selectedCard, setSelectedCard] = useState<CardValue>(
     socket.state.votes[socket.loginData.user]
   );
 
@@ -134,7 +133,7 @@ const ProtoVotingPage = ({ socket }: { socket: WebSocketApi }) => {
       <select
         name="scale"
         className="select"
-        onChange={(e) => socket.setScale(SCALE_MAPPING[e.target.value])}
+        onChange={(e) => socket.setScale(SCALE_MAPPING[(e.target as HTMLSelectElement).value])}
         value={'CHANGE_SCALE'}
       >
         <option value="CHANGE_SCALE" disabled>

--- a/frontend/src/Components/VotingStateDisplay.tsx
+++ b/frontend/src/Components/VotingStateDisplay.tsx
@@ -1,11 +1,10 @@
 import css from 'csz';
-import * as React from 'react';
 import { tableStyle } from '../styles.js';
 import { Votes, WebSocketApi } from '../types/WebSocket.js';
-import { connectToWebSocket } from './WebSocket.js';
-import { VotedIcon } from './VotedIcon';
 import { NotVotedIcon } from './NotVotedIcon';
 import { ObserverIcon } from './ObserverIcon';
+import { VotedIcon } from './VotedIcon';
+import { connectToWebSocket } from './WebSocket.js';
 
 const votingStateDisplayStyle = css`,
   ${tableStyle}
@@ -70,9 +69,7 @@ const ProtoVotingStateDisplay = ({ socket }: { socket: WebSocketApi }) => (
         return (
           <tr key={user}>
             <td className={getClassName(voted, observer)}>{user}</td>
-            <td align="center" className={getClassName(voted, observer)}>
-              {getIcon(voted, observer)}
-            </td>
+            <td className={getClassName(voted, observer)}>{getIcon(voted, observer)}</td>
           </tr>
         );
       })}

--- a/frontend/src/Components/WebSocket.tsx
+++ b/frontend/src/Components/WebSocket.tsx
@@ -1,6 +1,7 @@
-import * as React from 'react';
-import { Component } from 'react';
+import { ComponentType, createContext } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
 import { WEBSOCKET_URL } from '../config.js';
+import { COHEN_SCALE } from '../constants';
 import {
   getLoginRequest,
   getRemoveUsersNotVotedRequest,
@@ -17,7 +18,6 @@ import {
   WebsocketMessage,
   WebSocketState,
 } from '../types/WebSocket.js';
-import { COHEN_SCALE } from '../constants';
 
 const doNothing = () => {};
 
@@ -27,7 +27,7 @@ const initialWebSocketState: WebSocketState = {
   scale: COHEN_SCALE,
 };
 const initialLoginData: WebSocketLoginData = { user: '', session: '' };
-const WebSocketContext = React.createContext<WebSocketApi>({
+const WebSocketContext = createContext<WebSocketApi>({
   login: doNothing,
   loginData: initialLoginData,
   loggedIn: false,
@@ -46,12 +46,12 @@ function getVotes(votes: Votes): Votes {
 }
 
 export const WebSocketProvider = ({ children }: any) => {
-  const [socket, setSocket] = React.useState<WebSocket | null>(null);
-  const [state, setState] = React.useState(initialWebSocketState);
-  const [loginData, setLoginData] = React.useState(initialLoginData);
-  const [loggedIn, setLoggedIn] = React.useState(false);
+  const [socket, setSocket] = useState<WebSocket | null>(null);
+  const [state, setState] = useState(initialWebSocketState);
+  const [loginData, setLoginData] = useState(initialLoginData);
+  const [loggedIn, setLoggedIn] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!socket) {
       const webSocket = new WebSocket(WEBSOCKET_URL);
       webSocket.onopen = () => {
@@ -144,7 +144,7 @@ export const WebSocketProvider = ({ children }: any) => {
 export const WebSocketConsumer = WebSocketContext.Consumer;
 
 type ConnectToWebSocket<P extends {} = {}> = (
-  Component: React.ComponentType<
+  Component: ComponentType<
     {
       [K in keyof P | 'socket']: K extends 'socket'
         ? WebSocketApi
@@ -153,7 +153,7 @@ type ConnectToWebSocket<P extends {} = {}> = (
         : never;
     }
   >
-) => React.ComponentType<P>;
+) => ComponentType<P>;
 
 export const connectToWebSocket: ConnectToWebSocket = (Component) => (...props) => {
   return (

--- a/frontend/src/index.test.tsx
+++ b/frontend/src/index.test.tsx
@@ -1,13 +1,10 @@
 describe('the entry point', () => {
   it('displays the app as loading initially', () => {
-    const container = document.createElement('div');
-    container.id = 'root';
-    document.body.appendChild(container);
     jest.isolateModules(() => {
       require('./index.js');
     });
-    const rootElement = document.getElementById('root');
-    expect(rootElement).toHaveTextContent('Connecting...');
-    container.remove();
+    expect(document.body).toHaveTextContent('Connecting...');
+    expect(document.body.children).toHaveLength(1);
+    document.body.firstChild!.remove();
   });
 });

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { render } from 'preact';
 import { App } from './Components/App.js';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+render(<App />, document.body);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "jsx": "react",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "module": "ESNext",
     "moduleResolution": "Node",
     "outDir": "build",


### PR DESCRIPTION
Now this was much easier than I thought. This replaces React everywhere with [Preact](https://preactjs.com/). The effects are drastic: Our 153kB JavaScript bundle suddenly shrinks down to 37kB which is *less than a quarter of the original size*. There should be no performance degradation as we are not rendering anything complex anyway.

I did not change anything about the build setup to keep the PR small and simple. Future plan would be to switch the setup entirely to [WMR](https://github.com/preactjs/wmr), which might even give us pre-rendering of the initial view (apart from the amazing dev experience).