### PR TITLE
Prevent hovering animation on mobile

### DIFF
--- a/frontend/src/Components/App.tsx
+++ b/frontend/src/Components/App.tsx
@@ -1,11 +1,14 @@
 import classes from './App.module.css';
 import { PageSelector } from './PageSelector';
+import { TouchDetector } from './TouchDetector';
 import { WebSocketProvider } from './WebSocket';
 
 export const App = () => (
   <div className={classes.app}>
     <WebSocketProvider>
-      <PageSelector />
+      <TouchDetector>
+        <PageSelector />
+      </TouchDetector>
     </WebSocketProvider>
   </div>
 );

--- a/frontend/src/Components/CardSelector.module.css
+++ b/frontend/src/Components/CardSelector.module.css
@@ -32,7 +32,7 @@
 
 .card:active,
 .card:focus,
-.card:hover {
+:global(no-touch).card:hover {
   background: var(--light-blue);
   color: white;
   fill: white;
@@ -45,7 +45,7 @@
   fill: var(--light-gray);
 }
 
-.card.selected:hover {
+:global(no-touch).card.selected:hover {
   color: white;
   fill: white;
   border-color: var(--light-blue);

--- a/frontend/src/Components/TouchDetector.tsx
+++ b/frontend/src/Components/TouchDetector.tsx
@@ -1,0 +1,12 @@
+import classNames from 'classnames';
+import { useState } from 'preact/hooks';
+import { JSXInternal } from 'preact/src/jsx';
+
+export const TouchDetector = ({ children }: { children: JSXInternal.Element }) => {
+  const [usesTouch, setUsesTouch] = useState<boolean>(false);
+  return (
+    <div className={classNames({ 'no-touch': !usesTouch })} onTouchStart={() => setUsesTouch(true)}>
+      {children}
+    </div>
+  );
+};

--- a/frontend/src/styles.module.css
+++ b/frontend/src/styles.module.css
@@ -11,7 +11,7 @@
   width: var(--button-width);
 }
 
-.button:hover,
+:global(no-touch).button:hover,
 .button:focus {
   color: white;
   background: var(--light-blue);
@@ -23,7 +23,7 @@
   cursor: not-allowed;
 }
 
-.button:hover:active {
+:global(no-touch).button:hover:active {
   background: var(--tng-blue);
 }
 


### PR DESCRIPTION
On iOS when clicking the login button at a position where after login there is a card, the card gets a hover animation. After trying several things, I decided to just detect touch interaction and on first interaction just switch off all hover styling.