### PR TITLE
Improve icon alignment

### DIFF
--- a/frontend/src/Components/NotVotedIcon.tsx
+++ b/frontend/src/Components/NotVotedIcon.tsx
@@ -1,6 +1,8 @@
+import sharedClasses from '../styles.module.css';
+
 // taken from material ui icons
 export const NotVotedIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className={sharedClasses.icon}>
     <path d="M0 0h24v24H0V0z" fill="none" opacity=".87" />
     <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm3.59-13L12 10.59 8.41 7 7 8.41 10.59 12 7 15.59 8.41 17 12 13.41 15.59 17 17 15.59 13.41 12 17 8.41z" />
   </svg>

--- a/frontend/src/Components/ObserverIcon.tsx
+++ b/frontend/src/Components/ObserverIcon.tsx
@@ -1,6 +1,8 @@
+import sharedClasses from '../styles.module.css';
+
 // taken from material ui icons
 export const ObserverIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className={sharedClasses.icon}>
     <path d="M0 0h24v24H0V0z" fill="none" />
     <path d="M12 6c3.79 0 7.17 2.13 8.82 5.5C19.17 14.87 15.79 17 12 17s-7.17-2.13-8.82-5.5C4.83 8.13 8.21 6 12 6m0-2C7 4 2.73 7.11 1 11.5 2.73 15.89 7 19 12 19s9.27-3.11 11-7.5C21.27 7.11 17 4 12 4zm0 5c1.38 0 2.5 1.12 2.5 2.5S13.38 14 12 14s-2.5-1.12-2.5-2.5S10.62 9 12 9m0-2c-2.48 0-4.5 2.02-4.5 4.5S9.52 16 12 16s4.5-2.02 4.5-4.5S14.48 7 12 7z" />
   </svg>

--- a/frontend/src/Components/ResultsPage/ResultsPage.module.css
+++ b/frontend/src/Components/ResultsPage/ResultsPage.module.css
@@ -8,13 +8,8 @@
 .notVotedEntry {
   color: var(--tng-gray);
   fill: var(--tng-gray);
-  text-align: center;
 }
 
 .votedEntry {
   text-align: center;
-}
-
-.nameEntry {
-  line-height: 1.5rem;
 }

--- a/frontend/src/Components/ResultsPage/ResultsPage.tsx
+++ b/frontend/src/Components/ResultsPage/ResultsPage.tsx
@@ -43,7 +43,7 @@ const ProtoResultsPage = ({ socket }: { socket: WebSocketApi }) => (
           {getSortedResultsArray(socket.state.votes).map((userAndVote) => {
             return (
               <tr key={userAndVote[0]}>
-                <td className={classes.nameEntry}>{userAndVote[0]}</td>
+                <td>{userAndVote[0]}</td>
                 <td className={getClassName(userAndVote[1])}>{getVote(userAndVote[1])}</td>
               </tr>
             );

--- a/frontend/src/Components/VotedIcon.tsx
+++ b/frontend/src/Components/VotedIcon.tsx
@@ -1,6 +1,8 @@
+import sharedClasses from '../styles.module.css';
+
 // taken from material ui icons
 export const VotedIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className={sharedClasses.icon}>
     <path d="M0 0h24v24H0V0z" fill="none" />
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm4.59-12.42L10 14.17l-2.59-2.58L6 13l4 4 8-8z" />
   </svg>

--- a/frontend/src/Components/VotingStateDisplay.module.css
+++ b/frontend/src/Components/VotingStateDisplay.module.css
@@ -12,7 +12,3 @@
   color: var(--tng-blue);
   fill: var(--tng-blue);
 }
-
-.votedIcon {
-  text-align: center;
-}

--- a/frontend/src/Components/VotingStateDisplay.tsx
+++ b/frontend/src/Components/VotingStateDisplay.tsx
@@ -66,7 +66,7 @@ const ProtoVotingStateDisplay = ({ socket }: { socket: WebSocketApi }) => (
           return (
             <tr key={user} className={getClassName(voted, observer)}>
               <td>{user}</td>
-              <td className={classes.votedIcon}>{getIcon(voted, observer)}</td>
+              <td>{getIcon(voted, observer)}</td>
             </tr>
           );
         })}

--- a/frontend/src/styles.module.css
+++ b/frontend/src/styles.module.css
@@ -32,6 +32,7 @@
   padding: 0.25rem;
   border-spacing: 0.5rem 0;
   margin: auto;
+  line-height: 1.5rem;
 }
 
 .blueBorder {
@@ -45,4 +46,11 @@
 .headerRow {
   color: var(--tng-blue);
   line-height: 35px;
+}
+
+.icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  display: block;
+  margin: auto;
 }


### PR DESCRIPTION
This will make sure icons are aligned properly for not-voted/voted/observer. The best way I found was to set them to display as blocks and then set the line-height for the text equal to the image height.