### PR TITLE
Extract API URL from code

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig-test.json',
     },
+    API_URL: 'wss://api.url',
   },
   moduleFileExtensions: ['js', 'ts', 'tsx', 'mjs'],
   moduleNameMapper: {

--- a/frontend/src/Components/App.test.tsx
+++ b/frontend/src/Components/App.test.tsx
@@ -59,7 +59,7 @@ describe('The App component', () => {
     const { container } = render(<App />);
     expect(socketInstances).toHaveLength(1);
     const socket = socketInstances[0];
-    expect(socket.test_url).toBe('wss://scrum-poker-backend.playground.aws.tngtech.com');
+    expect(socket.test_url).toBe('wss://api.url');
     expect(typeof socket.onopen).toBe('function');
     expect(typeof socket.onmessage).toBe('function');
 

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,1 +1,4 @@
-export const WEBSOCKET_URL = 'wss://scrum-poker-backend.playground.aws.tngtech.com';
+// This will be injected by Vite/Rollup
+declare var API_URL: string;
+
+export const WEBSOCKET_URL = API_URL;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,12 @@
 import preact from '@preact/preset-vite';
 import { defineConfig } from 'vite';
+import replace from '@rollup/plugin-replace';
 
 export default defineConfig({
-  plugins: [preact()],
+  plugins: [
+    preact(),
+    replace({
+      API_URL: JSON.stringify('wss://api.scrum-poker.aws.tngtech.com'),
+    }),
+  ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -823,6 +823,32 @@
         "@rollup/pluginutils": "^4.1.0"
       }
     },
+    "@rollup/plugin-replace": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
+      "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+        }
+      }
+    },
     "@rollup/pluginutils": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
@@ -1027,6 +1053,11 @@
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
       "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw=="
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -4664,6 +4695,14 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
     },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5994,6 +6033,11 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "spdx-correct": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/tng/next-generation-scrum-poker#readme",
   "dependencies": {
     "@preact/preset-vite": "^2.0.1",
+    "@rollup/plugin-replace": "^2.4.2",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/preact": "^2.0.1",
     "@types/aws-lambda": "^8.10.73",


### PR DESCRIPTION
Extract the hard-coded API url from the production code into a Rollup/Vite plugin. At a later point, this url can then easily be replaced by something like `process.env.SCRUM_POKER_API`.