### PR TITLE
[RFC] Improve reveal behaviour in case not everyone has voted

### DIFF
--- a/frontend/src/Components/App.module.css
+++ b/frontend/src/Components/App.module.css
@@ -5,17 +5,14 @@
   --light-blue: hsl(205, 95%, 40%);
   --tng-gray: rgb(161, 166, 174);
   --light-gray: hsl(217, 8%, 94%);
+  --dark-red: hsl(0, 100%, 40%);
+  --red: hsl(0, 100%, 50%);
 }
 
 @media (min-width: 300px) {
   :root {
     --button-width: 14rem;
   }
-}
-
-:global body {
-  font: 16px sans-serif;
-  margin: 0;
 }
 
 :global * {
@@ -26,17 +23,34 @@
   outline: none;
 }
 
+:global body {
+  font: 16px sans-serif;
+  margin: 0;
+}
+
 :global input[type='text'],
 :global input[type='submit'],
 :global button,
 :global select {
   font-size: 1rem;
-  line-height: 2rem;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   border: none;
+  margin: 0;
   border-radius: var(--border-radius);
+}
+
+:global input[type='text'] {
+  line-height: 2rem;
+  padding: 0 0.5rem;
+}
+
+:global input[type='submit'],
+:global button,
+:global select {
+  line-height: 2.25rem;
+  padding: 0;
 }
 
 :global input[type='text'] {

--- a/frontend/src/Components/RevealButton.module.css
+++ b/frontend/src/Components/RevealButton.module.css
@@ -1,6 +1,26 @@
-.revealButton {
-  composes: button from '../styles.module.css';
-  height: 4rem;
+.revealButtonContainer {
   margin-top: 2.5rem;
   margin-bottom: 0.5rem;
+  text-align: center;
+  line-height: 2.25rem;
+}
+
+.revealButton {
+  composes: button from '../styles.module.css';
+  height: 4.5rem;
+}
+
+.revealNowButton {
+  composes: button from '../styles.module.css';
+  background-color: var(--dark-red);
+}
+
+:global(.no-touch) .revealNowButton:hover,
+.revealNowButton:focus {
+  color: white;
+  background: var(--red);
+}
+
+:global(.no-touch) .revealNowButton:hover:active {
+  background: var(--dark-red);
 }

--- a/frontend/src/Components/RevealButton.module.css
+++ b/frontend/src/Components/RevealButton.module.css
@@ -1,0 +1,6 @@
+.revealButton {
+  composes: button from '../styles.module.css';
+  height: 4rem;
+  margin-top: 2.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/Components/RevealButton.test.tsx
+++ b/frontend/src/Components/RevealButton.test.tsx
@@ -1,0 +1,95 @@
+import { getRenderWithWebSocket } from '../test-helpers/renderWithWebSocker';
+import { fireEvent, prettyDOM } from '@testing-library/preact';
+import { RevealButton } from './RevealButton';
+import { SCALES } from '../constants';
+
+const render = getRenderWithWebSocket(<RevealButton />, {
+  connected: true,
+  loginData: { user: 'TheUser', session: 'TheSession123456' },
+  loggedIn: true,
+  state: {
+    resultsVisible: false,
+    votes: {
+      TheUser: 'not-voted',
+    },
+    scale: SCALES.COHEN_SCALE.values,
+  },
+});
+
+describe('The RevealButton', () => {
+  it('reveals votes after everyone voted', () => {
+    const revealVotes = jest.fn();
+    const { getByText } = render({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: '3',
+          OtherUser: '5',
+        },
+      },
+    });
+
+    fireEvent.click(getByText('Reveal Votes'));
+    expect(revealVotes).toHaveBeenCalled();
+  });
+
+  it('does not reveal votes but shows a different view if votes are missing', () => {
+    const revealVotes = jest.fn();
+    const { getByText } = render({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: '3',
+          OtherUser: 'not-voted',
+        },
+      },
+    });
+
+    fireEvent.click(getByText('Reveal Votes'));
+    expect(revealVotes).not.toHaveBeenCalled();
+    getByText('1 people did not vote');
+
+    fireEvent.click(getByText('Reveal Now'));
+    expect(revealVotes).toHaveBeenCalled();
+  });
+
+  it('auto-updates the view and auto-reveals', () => {
+    const revealVotes = jest.fn();
+    const { getByText, rerender } = render({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: 'not-voted',
+          OtherUser: 'not-voted',
+        },
+      },
+    });
+
+    fireEvent.click(getByText('Reveal Votes'));
+    expect(revealVotes).not.toHaveBeenCalled();
+    getByText('2 people did not vote');
+
+    rerender({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: 'not-voted',
+          OtherUser: '5',
+        },
+      },
+    });
+    expect(revealVotes).not.toHaveBeenCalled();
+    getByText('1 people did not vote');
+
+    rerender({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: '3',
+          OtherUser: '5',
+        },
+      },
+    });
+    expect(revealVotes).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/Components/RevealButton.test.tsx
+++ b/frontend/src/Components/RevealButton.test.tsx
@@ -47,13 +47,29 @@ describe('The RevealButton', () => {
 
     fireEvent.click(getByText('Reveal Votes'));
     expect(revealVotes).not.toHaveBeenCalled();
-    getByText('1 people did not vote');
+    getByText('waiting for 1 missing votes…');
 
     fireEvent.click(getByText('Reveal Now'));
     expect(revealVotes).toHaveBeenCalled();
   });
 
-  it('auto-updates the view and auto-reveals', () => {
+  it('reveals if only the vote of the current user is missing', () => {
+    const revealVotes = jest.fn();
+    const { getByText } = render({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: 'not-voted',
+          OtherUser: '5',
+        },
+      },
+    });
+
+    fireEvent.click(getByText('Reveal Votes'));
+    expect(revealVotes).toHaveBeenCalled();
+  });
+
+  it('auto-updates the view and auto-reveals once missing votes have been added, not counting your own vote', () => {
     const revealVotes = jest.fn();
     const { getByText, rerender } = render({
       revealVotes,
@@ -61,32 +77,48 @@ describe('The RevealButton', () => {
         votes: {
           TheUser: 'not-voted',
           OtherUser: 'not-voted',
+          ThirdUser: 'not-voted',
         },
       },
     });
 
     fireEvent.click(getByText('Reveal Votes'));
     expect(revealVotes).not.toHaveBeenCalled();
-    getByText('2 people did not vote');
+    getByText('waiting for 2 missing votes…');
 
     rerender({
       revealVotes,
       state: {
         votes: {
           TheUser: 'not-voted',
-          OtherUser: '5',
+          OtherUser: '3',
+          ThirdUser: 'not-voted',
         },
       },
     });
     expect(revealVotes).not.toHaveBeenCalled();
-    getByText('1 people did not vote');
+    getByText('waiting for 1 missing votes…');
 
     rerender({
       revealVotes,
       state: {
         votes: {
-          TheUser: '3',
-          OtherUser: '5',
+          TheUser: '2',
+          OtherUser: '3',
+          ThirdUser: 'not-voted',
+        },
+      },
+    });
+    expect(revealVotes).not.toHaveBeenCalled();
+    getByText('waiting for 1 missing votes…');
+
+    rerender({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: '2',
+          OtherUser: '3',
+          ThirdUser: '5',
         },
       },
     });

--- a/frontend/src/Components/RevealButton.tsx
+++ b/frontend/src/Components/RevealButton.tsx
@@ -1,12 +1,51 @@
 import { WebSocketApi } from '../types/WebSocket';
 import classes from './RevealButton.module.css';
 import { connectToWebSocket } from './WebSocket';
-import { BUTTON_REVEAL_VOTES } from '../constants';
+import { BUTTON_REVEAL_VOTES, VOTE_NOTE_VOTED } from '../constants';
+import { useEffect, useState } from 'preact/hooks';
 
-const ProtoRevealButton = ({ socket }: { socket: WebSocketApi }) => (
-  <button class={classes.revealButton} onClick={() => socket.revealVotes()}>
-    {BUTTON_REVEAL_VOTES}
-  </button>
-);
+const ProtoRevealButton = ({
+  socket: {
+    revealVotes,
+    state: { votes },
+  },
+}: {
+  socket: WebSocketApi;
+}) => {
+  const [hasRequestedReveal, setHasRequestedReveal] = useState(false);
+  useEffect(() => {
+    if (hasRequestedReveal && Object.values(votes).every((vote) => vote !== VOTE_NOTE_VOTED)) {
+      revealVotes();
+    }
+  }, [votes]);
+
+  if (hasRequestedReveal) {
+    const missingVotes = Object.values(votes).filter((vote) => vote === VOTE_NOTE_VOTED).length;
+    return (
+      <div class={classes.revealButtonContainer}>
+        <div>{missingVotes} people did not vote</div>
+        <button class={classes.revealNowButton} onClick={revealVotes}>
+          Reveal Now
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div class={classes.revealButtonContainer}>
+      <button
+        class={classes.revealButton}
+        onClick={() => {
+          if (Object.values(votes).some((vote) => vote === VOTE_NOTE_VOTED)) {
+            setHasRequestedReveal(true);
+          } else {
+            revealVotes();
+          }
+        }}
+      >
+        {BUTTON_REVEAL_VOTES}
+      </button>
+    </div>
+  );
+};
 
 export const RevealButton = connectToWebSocket(ProtoRevealButton);

--- a/frontend/src/Components/RevealButton.tsx
+++ b/frontend/src/Components/RevealButton.tsx
@@ -1,0 +1,12 @@
+import { WebSocketApi } from '../types/WebSocket';
+import classes from './RevealButton.module.css';
+import { connectToWebSocket } from './WebSocket';
+import { BUTTON_REVEAL_VOTES } from '../constants';
+
+const ProtoRevealButton = ({ socket }: { socket: WebSocketApi }) => (
+  <button class={classes.revealButton} onClick={() => socket.revealVotes()}>
+    {BUTTON_REVEAL_VOTES}
+  </button>
+);
+
+export const RevealButton = connectToWebSocket(ProtoRevealButton);

--- a/frontend/src/Components/VotingPage.module.css
+++ b/frontend/src/Components/VotingPage.module.css
@@ -8,10 +8,3 @@
   composes: button from '../styles.module.css';
   margin-bottom: 0.75rem;
 }
-
-.revealButton {
-  composes: button;
-  height: 4rem;
-  margin-top: 2.5rem;
-  margin-bottom: 0.5rem;
-}

--- a/frontend/src/Components/VotingPage.tsx
+++ b/frontend/src/Components/VotingPage.tsx
@@ -6,14 +6,13 @@ import classes from './VotingPage.module.css';
 import { VotingStateDisplay } from './VotingStateDisplay';
 import { connectToWebSocket } from './WebSocket';
 import { BUTTON_KICK_NOT_VOTED, HEADING_SELECT_CARD } from '../constants';
+import { RevealButton } from './RevealButton';
 
 const ProtoVotingPage = ({ socket }: { socket: WebSocketApi }) => (
   <div class={classes.votingPage}>
     <div class={sharedClasses.heading}>{HEADING_SELECT_CARD}</div>
     <CardSelector />
-    <button class={classes.revealButton} onClick={() => socket.revealVotes()}>
-      Reveal Votes
-    </button>
+    <RevealButton />
     <VotingStateDisplay />
     <button class={classes.button} onClick={() => socket.removeUsersNotVoted()}>
       {BUTTON_KICK_NOT_VOTED}

--- a/frontend/src/Components/WebSocket.tsx
+++ b/frontend/src/Components/WebSocket.tsx
@@ -26,8 +26,10 @@ const initialWebSocketState: WebSocketState = {
   votes: {},
   scale: SCALES.COHEN_SCALE.values,
 };
+
 const initialLoginData: WebSocketLoginData = { user: '', session: '' };
-const WebSocketContext = createContext<WebSocketApi>({
+
+export const WebSocketContext = createContext<WebSocketApi>({
   connected: false,
   login: doNothing,
   loginData: initialLoginData,
@@ -142,11 +144,7 @@ export const WebSocketProvider = ({ children }: any) => {
     resetVotes,
     removeUsersNotVoted,
   };
-  return (
-    <WebSocketContext.Provider value={value} key="provider">
-      {children}
-    </WebSocketContext.Provider>
-  );
+  return <WebSocketContext.Provider value={value}>{children}</WebSocketContext.Provider>;
 };
 
 export const WebSocketConsumer = WebSocketContext.Consumer;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -36,6 +36,7 @@ export const LABEL_SESSION = 'Session:';
 export const BUTTON_LOGIN = 'Login';
 export const BUTTON_CONNECTING = 'Connecting…';
 export const BUTTON_OBSERVER = 'Observer';
+export const BUTTON_REVEAL_VOTES = 'Reveal Votes';
 export const BUTTON_KICK_NOT_VOTED = 'Kick users without vote';
 export const BUTTON_COPY_TO_CLIPBOARD = 'Copy Link to Clipboard';
 export const SELECT_CHANGE_SCALE = 'Change Scale';

--- a/frontend/src/test-helpers/renderWithWebSocker.tsx
+++ b/frontend/src/test-helpers/renderWithWebSocker.tsx
@@ -1,0 +1,56 @@
+import { ComponentChildren } from 'preact';
+import { WebSocketApi } from '../types/WebSocket';
+import { SCALES } from '../constants';
+import { render } from '@testing-library/preact';
+import { WebSocketContext } from '../Components/WebSocket';
+
+const doNothing = () => {};
+
+type PartialWebsocketApi = {
+  [P in keyof WebSocketApi]?: P extends 'state' ? Partial<WebSocketApi['state']> : WebSocketApi[P];
+};
+
+const getApi = (
+  defaultContext: PartialWebsocketApi,
+  context: PartialWebsocketApi
+): WebSocketApi => ({
+  connected: false,
+  login: doNothing,
+  loginData: { user: '', session: '' },
+  loggedIn: false,
+  setVote: doNothing,
+  setScale: doNothing,
+  revealVotes: doNothing,
+  resetVotes: doNothing,
+  removeUsersNotVoted: doNothing,
+  ...defaultContext,
+  ...context,
+  state: {
+    resultsVisible: false,
+    votes: {},
+    scale: SCALES.COHEN_SCALE.values,
+    ...defaultContext.state,
+    ...context.state,
+  },
+});
+
+export const getRenderWithWebSocket = (
+  children: ComponentChildren,
+  defaultApi: PartialWebsocketApi = {}
+) => (api: PartialWebsocketApi = {}) => {
+  const rendered = render(
+    <WebSocketContext.Provider value={getApi(defaultApi, api)}>
+      {children}
+    </WebSocketContext.Provider>
+  );
+  return {
+    ...rendered,
+    rerender(apiUpdate: PartialWebsocketApi = {}) {
+      rendered.rerender(
+        <WebSocketContext.Provider value={getApi(defaultApi, apiUpdate)}>
+          {children}
+        </WebSocketContext.Provider>
+      );
+    },
+  };
+};


### PR DESCRIPTION
Following some comments, this would add a safe-guard against revealing too early:
* If everyone has voted, reveal works as before
* If there are votes missing, clicking reveal will replace the reveal button with a count of missing votes and a smaller, red "Reveal Now" button
* Clicking "Reveal Now" works as before
* Otherwise, and **only if someone clicked "Reveal"**, the client will then auto-reveal once the last vote has been cast
* Of course the count of missing votes also auto-updates

<img width="240" alt="Confirm Reveal" src="https://user-images.githubusercontent.com/12949268/114374887-69537e80-9b84-11eb-8ab9-87e71e6a5474.png">

Also I set up a "unit test helper" that allows testing a WebSocket provider dependent component in isolation with given socket states and also simulate socket state changes.

This count will also ignore the current user. So if the current user did not vote, clicking "Reveal" will update immediately (we assume the user knows what they do). The current user will also be excluded from the count

<img width="263" alt="Exclude current user" src="https://user-images.githubusercontent.com/12949268/114375118-a4ee4880-9b84-11eb-8756-35987bf07b8b.png">

This is to disturb existing flows as little as possible.