### PR TITLE
Add Reveal button hint for missing votes

### DIFF
--- a/frontend/src/Components/App.module.css
+++ b/frontend/src/Components/App.module.css
@@ -5,17 +5,14 @@
   --light-blue: hsl(205, 95%, 40%);
   --tng-gray: rgb(161, 166, 174);
   --light-gray: hsl(217, 8%, 94%);
+  --dark-red: hsl(0, 100%, 40%);
+  --red: hsl(0, 100%, 50%);
 }
 
 @media (min-width: 300px) {
   :root {
     --button-width: 14rem;
   }
-}
-
-:global body {
-  font: 16px sans-serif;
-  margin: 0;
 }
 
 :global * {
@@ -26,17 +23,34 @@
   outline: none;
 }
 
+:global body {
+  font: 16px sans-serif;
+  margin: 0;
+}
+
 :global input[type='text'],
 :global input[type='submit'],
 :global button,
 :global select {
   font-size: 1rem;
-  line-height: 2rem;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   border: none;
+  margin: 0;
   border-radius: var(--border-radius);
+}
+
+:global input[type='text'] {
+  line-height: 2rem;
+  padding: 0 0.5rem;
+}
+
+:global input[type='submit'],
+:global button,
+:global select {
+  line-height: 2.25rem;
+  padding: 0;
 }
 
 :global input[type='text'] {

--- a/frontend/src/Components/RevealButton.module.css
+++ b/frontend/src/Components/RevealButton.module.css
@@ -5,22 +5,8 @@
   height: 4.5rem;
 }
 
-.revealNowButton {
-  composes: revealButton;
-  background-color: var(--dark-red);
-}
-
 .revealNowButtonInfo {
   font-size: 0.75rem;
+  margin-top: 0.75rem;
   line-height: 1;
-}
-
-:global(.no-touch) .revealNowButton:hover,
-.revealNowButton:focus {
-  color: white;
-  background: var(--red);
-}
-
-:global(.no-touch) .revealNowButton:hover:active {
-  background: var(--dark-red);
 }

--- a/frontend/src/Components/RevealButton.module.css
+++ b/frontend/src/Components/RevealButton.module.css
@@ -1,18 +1,18 @@
-.revealButtonContainer {
-  margin-top: 2.5rem;
-  margin-bottom: 0.5rem;
-  text-align: center;
-  line-height: 2.25rem;
-}
-
 .revealButton {
   composes: button from '../styles.module.css';
+  margin-top: 2.5rem;
+  margin-bottom: 0.5rem;
   height: 4.5rem;
 }
 
 .revealNowButton {
-  composes: button from '../styles.module.css';
+  composes: revealButton;
   background-color: var(--dark-red);
+}
+
+.revealNowButtonInfo {
+  font-size: 0.75rem;
+  line-height: 1;
 }
 
 :global(.no-touch) .revealNowButton:hover,

--- a/frontend/src/Components/RevealButton.module.css
+++ b/frontend/src/Components/RevealButton.module.css
@@ -1,6 +1,26 @@
-.revealButton {
-  composes: button from '../styles.module.css';
-  height: 4rem;
+.revealButtonContainer {
   margin-top: 2.5rem;
   margin-bottom: 0.5rem;
+  text-align: center;
+  line-height: 2.25rem;
+}
+
+.revealButton {
+  composes: button from '../styles.module.css';
+  height: 4.5rem;
+}
+
+.revealNowButton {
+  composes: button from '../styles.module.css';
+  background-color: var(--dark-red);
+}
+
+:global(.no-touch) .revealNowButton:hover,
+.revealNowButton:focus {
+  color: white;
+  background: var(--red);
+}
+
+:global(.no-touch) .revealNowButton:hover:active {
+  background: var(--dark-red);
 }

--- a/frontend/src/Components/RevealButton.module.css
+++ b/frontend/src/Components/RevealButton.module.css
@@ -1,0 +1,6 @@
+.revealButton {
+  composes: button from '../styles.module.css';
+  height: 4rem;
+  margin-top: 2.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/Components/RevealButton.test.tsx
+++ b/frontend/src/Components/RevealButton.test.tsx
@@ -49,7 +49,7 @@ describe('The RevealButton', () => {
     expect(revealVotes).toHaveBeenCalled();
   });
 
-  it('auto-updates the view and auto-reveals once missing votes have been added, not counting your own vote', () => {
+  it('auto-updates the view and auto-reveals once missing votes have been added', () => {
     const revealVotes = jest.fn();
     const { getByText, rerender } = render({
       revealVotes,
@@ -61,7 +61,7 @@ describe('The RevealButton', () => {
         },
       },
     });
-    expect(getByText('Reveal Now')).toHaveTextContent('2 missing votes');
+    expect(getByText('Reveal Now')).toHaveTextContent('3 missing votes');
 
     rerender({
       revealVotes,
@@ -73,7 +73,7 @@ describe('The RevealButton', () => {
         },
       },
     });
-    expect(getByText('Reveal Now')).toHaveTextContent('1 missing votes');
+    expect(getByText('Reveal Now')).toHaveTextContent('2 missing votes');
 
     rerender({
       revealVotes,

--- a/frontend/src/Components/RevealButton.test.tsx
+++ b/frontend/src/Components/RevealButton.test.tsx
@@ -1,0 +1,95 @@
+import { getRenderWithWebSocket } from '../test-helpers/renderWithWebSocker';
+import { fireEvent, prettyDOM } from '@testing-library/preact';
+import { RevealButton } from './RevealButton';
+import { SCALES } from '../constants';
+
+const render = getRenderWithWebSocket(<RevealButton />, {
+  connected: true,
+  loginData: { user: 'TheUser', session: 'TheSession123456' },
+  loggedIn: true,
+  state: {
+    resultsVisible: false,
+    votes: {
+      TheUser: 'not-voted',
+    },
+    scale: SCALES.COHEN_SCALE.values,
+  },
+});
+
+describe('The RevealButton', () => {
+  it('reveals votes after everyone voted', () => {
+    const revealVotes = jest.fn();
+    const { getByText } = render({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: '3',
+          OtherUser: '5',
+        },
+      },
+    });
+
+    fireEvent.click(getByText('Reveal Votes'));
+    expect(revealVotes).toHaveBeenCalled();
+  });
+
+  it('does not reveal votes but shows a different view if votes are missing', () => {
+    const revealVotes = jest.fn();
+    const { getByText } = render({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: '3',
+          OtherUser: 'not-voted',
+        },
+      },
+    });
+
+    fireEvent.click(getByText('Reveal Votes'));
+    expect(revealVotes).not.toHaveBeenCalled();
+    getByText('1 people did not vote');
+
+    fireEvent.click(getByText('Reveal Now'));
+    expect(revealVotes).toHaveBeenCalled();
+  });
+
+  it('auto-updates the view and auto-reveals', () => {
+    const revealVotes = jest.fn();
+    const { getByText, rerender } = render({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: 'not-voted',
+          OtherUser: 'not-voted',
+        },
+      },
+    });
+
+    fireEvent.click(getByText('Reveal Votes'));
+    expect(revealVotes).not.toHaveBeenCalled();
+    getByText('2 people did not vote');
+
+    rerender({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: 'not-voted',
+          OtherUser: '5',
+        },
+      },
+    });
+    expect(revealVotes).not.toHaveBeenCalled();
+    getByText('1 people did not vote');
+
+    rerender({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: '3',
+          OtherUser: '5',
+        },
+      },
+    });
+    expect(revealVotes).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/Components/RevealButton.test.tsx
+++ b/frontend/src/Components/RevealButton.test.tsx
@@ -33,7 +33,7 @@ describe('The RevealButton', () => {
     expect(revealVotes).toHaveBeenCalled();
   });
 
-  it('does not reveal votes but shows a different view if votes are missing', () => {
+  it('shows a different reveal button if votes are missing', () => {
     const revealVotes = jest.fn();
     const { getByText } = render({
       revealVotes,
@@ -45,27 +45,7 @@ describe('The RevealButton', () => {
       },
     });
 
-    fireEvent.click(getByText('Reveal Votes'));
-    expect(revealVotes).not.toHaveBeenCalled();
-    getByText('waiting for 1 missing votes…');
-
     fireEvent.click(getByText('Reveal Now'));
-    expect(revealVotes).toHaveBeenCalled();
-  });
-
-  it('reveals if only the vote of the current user is missing', () => {
-    const revealVotes = jest.fn();
-    const { getByText } = render({
-      revealVotes,
-      state: {
-        votes: {
-          TheUser: 'not-voted',
-          OtherUser: '5',
-        },
-      },
-    });
-
-    fireEvent.click(getByText('Reveal Votes'));
     expect(revealVotes).toHaveBeenCalled();
   });
 
@@ -81,10 +61,7 @@ describe('The RevealButton', () => {
         },
       },
     });
-
-    fireEvent.click(getByText('Reveal Votes'));
-    expect(revealVotes).not.toHaveBeenCalled();
-    getByText('waiting for 2 missing votes…');
+    expect(getByText('Reveal Now')).toHaveTextContent('2 missing votes');
 
     rerender({
       revealVotes,
@@ -96,8 +73,7 @@ describe('The RevealButton', () => {
         },
       },
     });
-    expect(revealVotes).not.toHaveBeenCalled();
-    getByText('waiting for 1 missing votes…');
+    expect(getByText('Reveal Now')).toHaveTextContent('1 missing votes');
 
     rerender({
       revealVotes,
@@ -109,8 +85,7 @@ describe('The RevealButton', () => {
         },
       },
     });
-    expect(revealVotes).not.toHaveBeenCalled();
-    getByText('waiting for 1 missing votes…');
+    expect(getByText('Reveal Now')).toHaveTextContent('1 missing votes');
 
     rerender({
       revealVotes,
@@ -122,6 +97,6 @@ describe('The RevealButton', () => {
         },
       },
     });
-    expect(revealVotes).toHaveBeenCalled();
+    getByText('Reveal Votes');
   });
 });

--- a/frontend/src/Components/RevealButton.test.tsx
+++ b/frontend/src/Components/RevealButton.test.tsx
@@ -47,13 +47,29 @@ describe('The RevealButton', () => {
 
     fireEvent.click(getByText('Reveal Votes'));
     expect(revealVotes).not.toHaveBeenCalled();
-    getByText('1 people did not vote');
+    getByText('waiting for 1 missing votes…');
 
     fireEvent.click(getByText('Reveal Now'));
     expect(revealVotes).toHaveBeenCalled();
   });
 
-  it('auto-updates the view and auto-reveals', () => {
+  it('reveals if only the vote of the current user is missing', () => {
+    const revealVotes = jest.fn();
+    const { getByText } = render({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: 'not-voted',
+          OtherUser: '5',
+        },
+      },
+    });
+
+    fireEvent.click(getByText('Reveal Votes'));
+    expect(revealVotes).toHaveBeenCalled();
+  });
+
+  it('auto-updates the view and auto-reveals once missing votes have been added, not counting your own vote', () => {
     const revealVotes = jest.fn();
     const { getByText, rerender } = render({
       revealVotes,
@@ -61,32 +77,48 @@ describe('The RevealButton', () => {
         votes: {
           TheUser: 'not-voted',
           OtherUser: 'not-voted',
+          ThirdUser: 'not-voted',
         },
       },
     });
 
     fireEvent.click(getByText('Reveal Votes'));
     expect(revealVotes).not.toHaveBeenCalled();
-    getByText('2 people did not vote');
+    getByText('waiting for 2 missing votes…');
 
     rerender({
       revealVotes,
       state: {
         votes: {
           TheUser: 'not-voted',
-          OtherUser: '5',
+          OtherUser: '3',
+          ThirdUser: 'not-voted',
         },
       },
     });
     expect(revealVotes).not.toHaveBeenCalled();
-    getByText('1 people did not vote');
+    getByText('waiting for 1 missing votes…');
 
     rerender({
       revealVotes,
       state: {
         votes: {
-          TheUser: '3',
-          OtherUser: '5',
+          TheUser: '2',
+          OtherUser: '3',
+          ThirdUser: 'not-voted',
+        },
+      },
+    });
+    expect(revealVotes).not.toHaveBeenCalled();
+    getByText('waiting for 1 missing votes…');
+
+    rerender({
+      revealVotes,
+      state: {
+        votes: {
+          TheUser: '2',
+          OtherUser: '3',
+          ThirdUser: '5',
         },
       },
     });

--- a/frontend/src/Components/RevealButton.tsx
+++ b/frontend/src/Components/RevealButton.tsx
@@ -1,12 +1,51 @@
 import { WebSocketApi } from '../types/WebSocket';
 import classes from './RevealButton.module.css';
 import { connectToWebSocket } from './WebSocket';
-import { BUTTON_REVEAL_VOTES } from '../constants';
+import { BUTTON_REVEAL_VOTES, VOTE_NOTE_VOTED } from '../constants';
+import { useEffect, useState } from 'preact/hooks';
 
-const ProtoRevealButton = ({ socket }: { socket: WebSocketApi }) => (
-  <button class={classes.revealButton} onClick={() => socket.revealVotes()}>
-    {BUTTON_REVEAL_VOTES}
-  </button>
-);
+const ProtoRevealButton = ({
+  socket: {
+    revealVotes,
+    state: { votes },
+  },
+}: {
+  socket: WebSocketApi;
+}) => {
+  const [hasRequestedReveal, setHasRequestedReveal] = useState(false);
+  useEffect(() => {
+    if (hasRequestedReveal && Object.values(votes).every((vote) => vote !== VOTE_NOTE_VOTED)) {
+      revealVotes();
+    }
+  }, [votes]);
+
+  if (hasRequestedReveal) {
+    const missingVotes = Object.values(votes).filter((vote) => vote === VOTE_NOTE_VOTED).length;
+    return (
+      <div class={classes.revealButtonContainer}>
+        <div>{missingVotes} people did not vote</div>
+        <button class={classes.revealNowButton} onClick={revealVotes}>
+          Reveal Now
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div class={classes.revealButtonContainer}>
+      <button
+        class={classes.revealButton}
+        onClick={() => {
+          if (Object.values(votes).some((vote) => vote === VOTE_NOTE_VOTED)) {
+            setHasRequestedReveal(true);
+          } else {
+            revealVotes();
+          }
+        }}
+      >
+        {BUTTON_REVEAL_VOTES}
+      </button>
+    </div>
+  );
+};
 
 export const RevealButton = connectToWebSocket(ProtoRevealButton);

--- a/frontend/src/Components/RevealButton.tsx
+++ b/frontend/src/Components/RevealButton.tsx
@@ -1,0 +1,12 @@
+import { WebSocketApi } from '../types/WebSocket';
+import classes from './RevealButton.module.css';
+import { connectToWebSocket } from './WebSocket';
+import { BUTTON_REVEAL_VOTES } from '../constants';
+
+const ProtoRevealButton = ({ socket }: { socket: WebSocketApi }) => (
+  <button class={classes.revealButton} onClick={() => socket.revealVotes()}>
+    {BUTTON_REVEAL_VOTES}
+  </button>
+);
+
+export const RevealButton = connectToWebSocket(ProtoRevealButton);

--- a/frontend/src/Components/RevealButton.tsx
+++ b/frontend/src/Components/RevealButton.tsx
@@ -1,8 +1,7 @@
 import { Votes, WebSocketApi } from '../types/WebSocket';
 import classes from './RevealButton.module.css';
 import { connectToWebSocket } from './WebSocket';
-import { BUTTON_REVEAL_VOTES, VOTE_NOTE_VOTED } from '../constants';
-import { useEffect, useState } from 'preact/hooks';
+import { BUTTON_REVEAL_NOW, BUTTON_REVEAL_VOTES, VOTE_NOTE_VOTED } from '../constants';
 
 const ProtoRevealButton = ({
   socket: {
@@ -13,38 +12,19 @@ const ProtoRevealButton = ({
 }: {
   socket: WebSocketApi;
 }) => {
-  const [hasRequestedReveal, setHasRequestedReveal] = useState(false);
-  useEffect(() => {
-    if (hasRequestedReveal && getNumberOfMissingVotes(votes, user) === 0) {
-      revealVotes();
-    }
-  }, [votes, user]);
-
-  if (hasRequestedReveal) {
+  const missingVotes = getNumberOfMissingVotes(votes, user);
+  if (missingVotes > 0) {
     return (
-      <div class={classes.revealButtonContainer}>
-        <div>waiting for {getNumberOfMissingVotes(votes, user)} missing votes…</div>
-        <button class={classes.revealNowButton} onClick={revealVotes}>
-          Reveal Now
-        </button>
-      </div>
+      <button class={classes.revealNowButton} onClick={revealVotes}>
+        <div class={classes.revealNowButtonInfo}>{missingVotes} missing votes</div>
+        {BUTTON_REVEAL_NOW}
+      </button>
     );
   }
   return (
-    <div class={classes.revealButtonContainer}>
-      <button
-        class={classes.revealButton}
-        onClick={() => {
-          if (getNumberOfMissingVotes(votes, user) > 0) {
-            setHasRequestedReveal(true);
-          } else {
-            revealVotes();
-          }
-        }}
-      >
-        {BUTTON_REVEAL_VOTES}
-      </button>
-    </div>
+    <button class={classes.revealButton} onClick={revealVotes}>
+      {BUTTON_REVEAL_VOTES}
+    </button>
   );
 };
 

--- a/frontend/src/Components/RevealButton.tsx
+++ b/frontend/src/Components/RevealButton.tsx
@@ -5,17 +5,16 @@ import { BUTTON_REVEAL_NOW, BUTTON_REVEAL_VOTES, VOTE_NOTE_VOTED } from '../cons
 
 const ProtoRevealButton = ({
   socket: {
-    loginData: { user },
     revealVotes,
     state: { votes },
   },
 }: {
   socket: WebSocketApi;
 }) => {
-  const missingVotes = getNumberOfMissingVotes(votes, user);
+  const missingVotes = getNumberOfMissingVotes(votes);
   if (missingVotes > 0) {
     return (
-      <button class={classes.revealNowButton} onClick={revealVotes}>
+      <button class={classes.revealButton} onClick={revealVotes}>
         <div class={classes.revealNowButtonInfo}>{missingVotes} missing votes</div>
         {BUTTON_REVEAL_NOW}
       </button>
@@ -28,8 +27,7 @@ const ProtoRevealButton = ({
   );
 };
 
-const getNumberOfMissingVotes = (votes: Votes, currentUser: string): number =>
-  Object.entries(votes).filter(([user, vote]) => vote === VOTE_NOTE_VOTED && user !== currentUser)
-    .length;
+const getNumberOfMissingVotes = (votes: Votes): number =>
+  Object.values(votes).reduce((count, vote) => (vote === VOTE_NOTE_VOTED ? count + 1 : count), 0);
 
 export const RevealButton = connectToWebSocket(ProtoRevealButton);

--- a/frontend/src/Components/VotingPage.module.css
+++ b/frontend/src/Components/VotingPage.module.css
@@ -9,10 +9,3 @@
   composes: button from '../styles.module.css';
   margin-bottom: 0.75rem;
 }
-
-.revealButton {
-  composes: button;
-  height: 4rem;
-  margin-top: 2.5rem;
-  margin-bottom: 0.5rem;
-}

--- a/frontend/src/Components/VotingPage.tsx
+++ b/frontend/src/Components/VotingPage.tsx
@@ -6,14 +6,13 @@ import classes from './VotingPage.module.css';
 import { VotingStateDisplay } from './VotingStateDisplay';
 import { connectToWebSocket } from './WebSocket';
 import { BUTTON_KICK_NOT_VOTED, HEADING_SELECT_CARD } from '../constants';
+import { RevealButton } from './RevealButton';
 
 const ProtoVotingPage = ({ socket }: { socket: WebSocketApi }) => (
   <div class={classes.votingPage}>
     <div class={sharedClasses.heading}>{HEADING_SELECT_CARD}</div>
     <CardSelector />
-    <button class={classes.revealButton} onClick={() => socket.revealVotes()}>
-      Reveal Votes
-    </button>
+    <RevealButton />
     <VotingStateDisplay />
     <button class={classes.button} onClick={() => socket.removeUsersNotVoted()}>
       {BUTTON_KICK_NOT_VOTED}

--- a/frontend/src/Components/WebSocket.tsx
+++ b/frontend/src/Components/WebSocket.tsx
@@ -26,8 +26,10 @@ const initialWebSocketState: WebSocketState = {
   votes: {},
   scale: SCALES.COHEN_SCALE.values,
 };
+
 const initialLoginData: WebSocketLoginData = { user: '', session: '' };
-const WebSocketContext = createContext<WebSocketApi>({
+
+export const WebSocketContext = createContext<WebSocketApi>({
   connected: false,
   login: doNothing,
   loginData: initialLoginData,
@@ -142,11 +144,7 @@ export const WebSocketProvider = ({ children }: any) => {
     resetVotes,
     removeUsersNotVoted,
   };
-  return (
-    <WebSocketContext.Provider value={value} key="provider">
-      {children}
-    </WebSocketContext.Provider>
-  );
+  return <WebSocketContext.Provider value={value}>{children}</WebSocketContext.Provider>;
 };
 
 export const WebSocketConsumer = WebSocketContext.Consumer;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -36,6 +36,7 @@ export const LABEL_SESSION = 'Session:';
 export const BUTTON_LOGIN = 'Login';
 export const BUTTON_CONNECTING = 'Connecting…';
 export const BUTTON_OBSERVER = 'Observer';
+export const BUTTON_REVEAL_VOTES = 'Reveal Votes';
 export const BUTTON_KICK_NOT_VOTED = 'Kick users without vote';
 export const BUTTON_COPY_TO_CLIPBOARD = 'Copy Link to Clipboard';
 export const SELECT_CHANGE_SCALE = 'Change Scale';

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -37,6 +37,7 @@ export const BUTTON_LOGIN = 'Login';
 export const BUTTON_CONNECTING = 'Connecting…';
 export const BUTTON_OBSERVER = 'Observer';
 export const BUTTON_REVEAL_VOTES = 'Reveal Votes';
+export const BUTTON_REVEAL_NOW = 'Reveal Now';
 export const BUTTON_KICK_NOT_VOTED = 'Kick users without vote';
 export const BUTTON_COPY_TO_CLIPBOARD = 'Copy Link to Clipboard';
 export const SELECT_CHANGE_SCALE = 'Change Scale';

--- a/frontend/src/test-helpers/renderWithWebSocker.tsx
+++ b/frontend/src/test-helpers/renderWithWebSocker.tsx
@@ -1,0 +1,56 @@
+import { ComponentChildren } from 'preact';
+import { WebSocketApi } from '../types/WebSocket';
+import { SCALES } from '../constants';
+import { render } from '@testing-library/preact';
+import { WebSocketContext } from '../Components/WebSocket';
+
+const doNothing = () => {};
+
+type PartialWebsocketApi = {
+  [P in keyof WebSocketApi]?: P extends 'state' ? Partial<WebSocketApi['state']> : WebSocketApi[P];
+};
+
+const getApi = (
+  defaultContext: PartialWebsocketApi,
+  context: PartialWebsocketApi
+): WebSocketApi => ({
+  connected: false,
+  login: doNothing,
+  loginData: { user: '', session: '' },
+  loggedIn: false,
+  setVote: doNothing,
+  setScale: doNothing,
+  revealVotes: doNothing,
+  resetVotes: doNothing,
+  removeUsersNotVoted: doNothing,
+  ...defaultContext,
+  ...context,
+  state: {
+    resultsVisible: false,
+    votes: {},
+    scale: SCALES.COHEN_SCALE.values,
+    ...defaultContext.state,
+    ...context.state,
+  },
+});
+
+export const getRenderWithWebSocket = (
+  children: ComponentChildren,
+  defaultApi: PartialWebsocketApi = {}
+) => (api: PartialWebsocketApi = {}) => {
+  const rendered = render(
+    <WebSocketContext.Provider value={getApi(defaultApi, api)}>
+      {children}
+    </WebSocketContext.Provider>
+  );
+  return {
+    ...rendered,
+    rerender(apiUpdate: PartialWebsocketApi = {}) {
+      rendered.rerender(
+        <WebSocketContext.Provider value={getApi(defaultApi, apiUpdate)}>
+          {children}
+        </WebSocketContext.Provider>
+      );
+    },
+  };
+};


### PR DESCRIPTION
This is an alternative approach to #57.

Instead of the two-step process, the button will be displayed with a hint for the number of votes.

<img width="260" alt="Bildschirmfoto 2021-04-19 um 17 27 49" src="https://user-images.githubusercontent.com/12949268/115262218-9da2de00-a134-11eb-9dbd-bc6ab4964280.png">

