### PR TITLE
Enable user to unselect a card:

### DIFF
--- a/frontend/src/Components/CardSelector.module.css
+++ b/frontend/src/Components/CardSelector.module.css
@@ -38,8 +38,7 @@
   margin-left: 0.5rem;
 }
 
-.card:active,
-.card:focus,
+.card:focus-visible,
 :global(.no-touch) .card:hover {
   background: var(--light-blue);
   color: white;

--- a/frontend/src/Components/CardSelector.test.tsx
+++ b/frontend/src/Components/CardSelector.test.tsx
@@ -40,7 +40,7 @@ describe('The CardSelector', () => {
     fireEvent.click(getByTitle('Need a break'));
 
     // then
-    expect(setVote).toHaveBeenNthCalledWith(2,'coffee');
+    expect(setVote).toHaveBeenNthCalledWith(2, 'coffee');
   });
 
   it('lets the user unselect a card', () => {
@@ -77,6 +77,6 @@ describe('The CardSelector', () => {
     fireEvent.click(getByText('1'));
 
     // then
-    expect(setVote).toHaveBeenNthCalledWith(2,'not-voted');
+    expect(setVote).toHaveBeenNthCalledWith(2, 'not-voted');
   });
 });

--- a/frontend/src/Components/CardSelector.test.tsx
+++ b/frontend/src/Components/CardSelector.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent } from '@testing-library/preact';
+import { SCALES } from '../constants';
+import { getRenderWithWebSocket } from '../test-helpers/renderWithWebSocker';
+import { CardSelector } from './CardSelector';
+
+const render = getRenderWithWebSocket(<CardSelector />, {
+  connected: true,
+  loginData: { user: 'TheUser', session: 'TheSession123456' },
+  loggedIn: true,
+  state: {
+    resultsVisible: false,
+    votes: {
+      TheUser: 'not-voted',
+    },
+    scale: SCALES.COHEN_SCALE.values,
+  },
+});
+
+describe('The CardSelector', () => {
+  it('lets the user pick different card values', () => {
+    // given
+    const setVote = jest.fn();
+    const { getByText, getByTitle } = render({
+      setVote,
+      state: {
+        votes: {
+          TheUser: 'not-voted',
+          OtherUser: '5',
+        },
+      },
+    });
+
+    // when
+    fireEvent.click(getByText('1'));
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(1, '1');
+
+    // when
+    fireEvent.click(getByTitle('Need a break'));
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(2,'coffee');
+  });
+
+  it('lets the user unselect a card', () => {
+    // given
+    const setVote = jest.fn();
+    const { getByText, rerender } = render({
+      setVote,
+      state: {
+        votes: {
+          TheUser: 'not-voted',
+          OtherUser: '5',
+        },
+      },
+    });
+
+    // when
+    fireEvent.click(getByText('1'));
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(1, '1');
+
+    // when
+    rerender({
+      setVote,
+      state: {
+        votes: {
+          TheUser: '1',
+          OtherUser: '5',
+        },
+      },
+    });
+
+    // when
+    fireEvent.click(getByText('1'));
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(2,'not-voted');
+  });
+});

--- a/frontend/src/Components/CardSelector.tsx
+++ b/frontend/src/Components/CardSelector.tsx
@@ -4,25 +4,31 @@ import classes from './CardSelector.module.css';
 import { IconCoffee } from './IconCoffee';
 import { connectToWebSocket } from './WebSocket';
 import { IconObserver } from './IconObserver';
-import { BUTTON_OBSERVER, VOTE_COFFEE, VOTE_OBSERVER } from '../constants';
+import { BUTTON_OBSERVER, VOTE_COFFEE, VOTE_NOTE_VOTED, VOTE_OBSERVER } from '../constants';
 
 const ProtoCardSelector = ({ socket }: { socket: WebSocketApi }) => {
   const selectedCard = socket.state.votes[socket.loginData.user];
+
   return (
     <>
       <div class={classes.cardCollection}>
-        {socket.state.scale.map((cardValue) => (
-          <button
-            key={cardValue}
-            class={classNames([
-              classes.largeCard,
-              { [classes.selected]: selectedCard === cardValue },
-            ])}
-            onClick={() => socket.setVote(cardValue)}
-          >
-            {cardValue === VOTE_COFFEE ? <IconCoffee /> : cardValue}
-          </button>
-        ))}
+        {socket.state.scale.map((cardValue) => {
+          return (
+            <button
+              key={cardValue}
+              class={selectedCard === cardValue ? classNames([classes.largeCard, classes.selected]) : classNames([classes.largeCard])}
+              onClick={() => {
+                if (selectedCard === cardValue) {
+                  socket.setVote(VOTE_NOTE_VOTED);
+                } else {
+                  socket.setVote(cardValue);
+                }
+              }}
+            >
+              {cardValue === VOTE_COFFEE ? <IconCoffee /> : cardValue}
+            </button>
+          );
+        })}
       </div>
       <button
         class={classNames([

--- a/frontend/src/Components/CardSelector.tsx
+++ b/frontend/src/Components/CardSelector.tsx
@@ -11,25 +11,24 @@ const SPECIAL_ICONS: { [value in CardValue]?: JSX.Element } = {
   [VOTE_OBSERVER]: <IconObserver />,
   [VOTE_COFFEE]: <IconCoffee />,
 };
-const getCard = (
-  cardValue: CardValue,
-  isSelected: boolean,
-  isObserver: boolean,
-  socket: WebSocketApi
-) => (
-  <button
-    key={cardValue}
-    class={classNames({
-      [classes.buttonObserver]: isObserver,
-      [classes.largeCard]: !isObserver,
-      [classes.selected]: isSelected,
-    })}
-    onClick={() => socket.setVote(isSelected ? VOTE_NOTE_VOTED : cardValue)}
-  >
-    {SPECIAL_ICONS[cardValue] || cardValue}
-    {isObserver && <div class={classes.buttonObserverText}>{BUTTON_OBSERVER}</div>}
-  </button>
-);
+const getCard = (cardValue: CardValue, isSelected: boolean, setVote: WebSocketApi['setVote']) => {
+  const isObserver = cardValue === VOTE_OBSERVER;
+
+  return (
+    <button
+      key={cardValue}
+      class={classNames({
+        [classes.buttonObserver]: isObserver,
+        [classes.largeCard]: !isObserver,
+        [classes.selected]: isSelected,
+      })}
+      onClick={() => setVote(isSelected ? VOTE_NOTE_VOTED : cardValue)}
+    >
+      {SPECIAL_ICONS[cardValue] || cardValue}
+      {isObserver && <div class={classes.buttonObserverText}>{BUTTON_OBSERVER}</div>}
+    </button>
+  );
+};
 
 const ProtoCardSelector = ({ socket }: { socket: WebSocketApi }) => {
   const selectedCard = socket.state.votes[socket.loginData.user];
@@ -38,10 +37,10 @@ const ProtoCardSelector = ({ socket }: { socket: WebSocketApi }) => {
     <>
       <div class={classes.cardCollection}>
         {socket.state.scale.map((cardValue) =>
-          getCard(cardValue, selectedCard === cardValue, false, socket)
+          getCard(cardValue, selectedCard === cardValue, socket.setVote)
         )}
       </div>
-      {getCard(VOTE_OBSERVER, selectedCard === VOTE_OBSERVER, true, socket)}
+      {getCard(VOTE_OBSERVER, selectedCard === VOTE_OBSERVER, socket.setVote)}
     </>
   );
 };

--- a/frontend/src/Components/RevealButton.test.tsx
+++ b/frontend/src/Components/RevealButton.test.tsx
@@ -1,5 +1,5 @@
 import { getRenderWithWebSocket } from '../test-helpers/renderWithWebSocker';
-import { fireEvent, prettyDOM } from '@testing-library/preact';
+import { fireEvent } from '@testing-library/preact';
 import { RevealButton } from './RevealButton';
 import { SCALES } from '../constants';
 


### PR DESCRIPTION
* Send the "not-voted" value upon click on the selected card
* Remove the CSS selector `.card:active`, which seemingly had no effect apart from breaking this feature
(please point out if I am wrong here)
* Replace the selector `.card:focus` by `.card:focus-visible`. We want to highlight cards on focus to enable
tab navigation, but this had an undesired effect: after unselecting a card, the card would be focused, thus
rendering it in light blue and providing a bad user experience: "Did I unselect the card or not?". The pseudo
class "focus-visible" correctly determines if the card was selected via keyboard (in which case it should be
focused) of via mouse (in which case it should NOT be focused)
* Also remove unused import in RevealButton.test.tsx