### PR TITLE
FEATURE: Allow selecting cards via keyboard

### DIFF
--- a/frontend/src/Components/CardSelector.test.tsx
+++ b/frontend/src/Components/CardSelector.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent } from '@testing-library/preact';
-import { SCALES } from '../constants';
+import { SCALES, VOTE_COFFEE, VOTE_NOTE_VOTED } from '../constants';
 import { getRenderWithWebSocket } from '../test-helpers/renderWithWebSocker';
 import { CardSelector } from './CardSelector';
 
@@ -22,17 +22,20 @@ describe('The CardSelector', () => {
 
   beforeAll(() => {
     originalAddEventListener = window.addEventListener;
-  })
+  });
 
   beforeEach(() => {
-    window.addEventListener = jest.fn((event: string, handler: EventListenerOrEventListenerObject) => {
-      onKeyDown = handler as EventListener
-    })
-  })
+    jest.resetAllMocks();
+    window.addEventListener = jest.fn(
+      (event: string, handler: EventListenerOrEventListenerObject) => {
+        onKeyDown = handler as EventListener;
+      }
+    );
+  });
 
   afterAll(() => {
     window.addEventListener = originalAddEventListener;
-  })
+  });
 
   it('lets the user pick different card values', () => {
     // given
@@ -102,31 +105,159 @@ describe('The CardSelector', () => {
     const setVote = jest.fn();
     render({
       setVote,
-      state: { votes: { TheUser: 'not-voted',  OtherUser: '5' } },
+      state: { votes: { TheUser: 'not-voted', OtherUser: '5' } },
     });
 
     // when
-    onKeyDown({ key: "1" } as unknown as Event)
+    onKeyDown(({ key: '1' } as unknown) as Event);
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(1, '1');
 
     // when
-    onKeyDown({ key: "2" } as unknown as Event)
+    onKeyDown(({ key: '2' } as unknown) as Event);
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(2, '2');
 
     // when
-    onKeyDown({ key: "4" } as unknown as Event) // Not available in the Cohen scale
+    onKeyDown(({ key: '9' } as unknown) as Event); // Not available in the Cohen scale
 
     // then
     expect(setVote).toHaveBeenCalledTimes(2);
 
     // when
-    onKeyDown({ key: "a" } as unknown as Event)
+    onKeyDown(({ key: 'a' } as unknown) as Event);
 
     // then
     expect(setVote).toHaveBeenCalledTimes(2);
+  });
+
+  it.each`
+    key    | selectedCard
+    ${'c'} | ${VOTE_COFFEE}
+    ${'C'} | ${VOTE_COFFEE}
+    ${'?'} | ${'?'}
+  `('lets the user pick the $selectedCard card with the keyboard', ({ key, selectedCard }) => {
+    // given
+    const setVote = jest.fn();
+    render({
+      setVote,
+      state: { votes: { TheUser: 'not-voted', OtherUser: '5' } },
+    });
+
+    // when
+    onKeyDown(({ key } as unknown) as Event);
+
+    // then
+    expect(setVote).toHaveBeenCalledWith(selectedCard);
+  });
+
+  it('lets the user unselect cards with the keyboard', () => {
+    // given
+    const setVote = jest.fn();
+    const { rerender } = render({
+      setVote,
+      state: { votes: { TheUser: 'not-voted', OtherUser: '5' } },
+    });
+
+    // when
+    onKeyDown(({ key: '3' } as unknown) as Event);
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(1, '3');
+
+    // when
+    rerender({
+      setVote,
+      state: { votes: { TheUser: '3', OtherUser: '5' } },
+    });
+
+    // when
+    onKeyDown(({ key: '3' } as unknown) as Event);
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(2, VOTE_NOTE_VOTED);
+  });
+
+  it('lets the user cycle through cards with the keyboard', () => {
+    // given
+    const setVote = jest.fn();
+    const { rerender } = render({
+      setVote,
+      state: { votes: { TheUser: 'not-voted', OtherUser: '5' } },
+    });
+
+    // when
+    onKeyDown(({ key: '1' } as unknown) as Event);
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(1, '1');
+
+    // when
+    rerender({ setVote, state: { votes: { TheUser: '1', OtherUser: '5' } } });
+
+    // when
+    onKeyDown(({ key: '1' } as unknown) as Event);
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(2, '13');
+
+    // when
+    rerender({ setVote, state: { votes: { TheUser: '13', OtherUser: '5' } } });
+
+    // when
+    onKeyDown(({ key: '1' } as unknown) as Event);
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(3, '100');
+
+    // when
+    rerender({
+      setVote,
+      state: { votes: { TheUser: '100', OtherUser: '5' } },
+    });
+
+    // when
+    onKeyDown(({ key: '1' } as unknown) as Event);
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(4, VOTE_NOTE_VOTED);
+
+    // when
+    rerender({
+      setVote,
+      state: { votes: { TheUser: '1', OtherUser: '5' } },
+    });
+  });
+
+  it('behaves case-insensitive when user selects cards via keyboard', () => {
+    // given
+    const setVote = jest.fn();
+    const { rerender } = render({
+      setVote,
+      state: { votes: { TheUser: 'not-voted', OtherUser: '5' }, scale: SCALES.SIZES_SCALE.values },
+    });
+
+    // when
+    onKeyDown(({ key: 's' } as unknown) as Event);
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(1, 'S');
+
+    // when
+    rerender({
+      setVote,
+      state: {
+        votes: { TheUser: 'not-voted', OtherUser: '5' },
+        scale: SCALES.SIZES_SCALE.values,
+      },
+    });
+
+    // when
+    onKeyDown(({ key: 'S' } as unknown) as Event);
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(2, 'S');
   });
 });

--- a/frontend/src/Components/CardSelector.test.tsx
+++ b/frontend/src/Components/CardSelector.test.tsx
@@ -156,19 +156,7 @@ describe('The CardSelector', () => {
   it('lets the user unselect cards with the keyboard', () => {
     // given
     const setVote = jest.fn();
-    const { rerender } = render({
-      setVote,
-      state: { votes: { TheUser: 'not-voted', OtherUser: '5' } },
-    });
-
-    // when
-    onKeyDown(({ key: '3' } as unknown) as Event);
-
-    // then
-    expect(setVote).toHaveBeenNthCalledWith(1, '3');
-
-    // when
-    rerender({
+    render({
       setVote,
       state: { votes: { TheUser: '3', OtherUser: '5' } },
     });
@@ -177,7 +165,7 @@ describe('The CardSelector', () => {
     onKeyDown(({ key: '3' } as unknown) as Event);
 
     // then
-    expect(setVote).toHaveBeenNthCalledWith(2, VOTE_NOTE_VOTED);
+    expect(setVote).toHaveBeenCalledWith(VOTE_NOTE_VOTED);
   });
 
   it('lets the user cycle through cards with the keyboard', () => {

--- a/frontend/src/Components/CardSelector.test.tsx
+++ b/frontend/src/Components/CardSelector.test.tsx
@@ -17,6 +17,23 @@ const render = getRenderWithWebSocket(<CardSelector />, {
 });
 
 describe('The CardSelector', () => {
+  let onKeyDown: EventListener;
+  let originalAddEventListener: typeof window.addEventListener;
+
+  beforeAll(() => {
+    originalAddEventListener = window.addEventListener;
+  })
+
+  beforeEach(() => {
+    window.addEventListener = jest.fn((event: string, handler: EventListenerOrEventListenerObject) => {
+      onKeyDown = handler as EventListener
+    })
+  })
+
+  afterAll(() => {
+    window.addEventListener = originalAddEventListener;
+  })
+
   it('lets the user pick different card values', () => {
     // given
     const setVote = jest.fn();
@@ -78,5 +95,38 @@ describe('The CardSelector', () => {
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(2, 'not-voted');
+  });
+
+  it('lets the user pick different card values with the keyboard', () => {
+    // given
+    const setVote = jest.fn();
+    render({
+      setVote,
+      state: { votes: { TheUser: 'not-voted',  OtherUser: '5' } },
+    });
+
+    // when
+    onKeyDown({ key: "1" } as unknown as Event)
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(1, '1');
+
+    // when
+    onKeyDown({ key: "2" } as unknown as Event)
+
+    // then
+    expect(setVote).toHaveBeenNthCalledWith(2, '2');
+
+    // when
+    onKeyDown({ key: "4" } as unknown as Event) // Not available in the Cohen scale
+
+    // then
+    expect(setVote).toHaveBeenCalledTimes(2);
+
+    // when
+    onKeyDown({ key: "a" } as unknown as Event)
+
+    // then
+    expect(setVote).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/Components/CardSelector.test.tsx
+++ b/frontend/src/Components/CardSelector.test.tsx
@@ -17,26 +17,6 @@ const render = getRenderWithWebSocket(<CardSelector />, {
 });
 
 describe('The CardSelector', () => {
-  let onKeyDown: EventListener;
-  let originalAddEventListener: typeof window.addEventListener;
-
-  beforeAll(() => {
-    originalAddEventListener = window.addEventListener;
-  });
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-    window.addEventListener = jest.fn(
-      (event: string, handler: EventListenerOrEventListenerObject) => {
-        onKeyDown = handler as EventListener;
-      }
-    );
-  });
-
-  afterAll(() => {
-    window.addEventListener = originalAddEventListener;
-  });
-
   it('lets the user pick different card values', () => {
     // given
     const setVote = jest.fn();
@@ -109,25 +89,25 @@ describe('The CardSelector', () => {
     });
 
     // when
-    onKeyDown(({ key: '1' } as unknown) as Event);
+    fireEvent.keyDown(window, { key: '1' });
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(1, '1');
 
     // when
-    onKeyDown(({ key: '2' } as unknown) as Event);
+    fireEvent.keyDown(window, { key: '2' });
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(2, '2');
 
     // when
-    onKeyDown(({ key: '9' } as unknown) as Event); // Not available in the Cohen scale
+    fireEvent.keyDown(window, { key: '9' });
 
     // then
     expect(setVote).toHaveBeenCalledTimes(2);
 
     // when
-    onKeyDown(({ key: 'a' } as unknown) as Event);
+    fireEvent.keyDown(window, { key: 'A' });
 
     // then
     expect(setVote).toHaveBeenCalledTimes(2);
@@ -147,7 +127,7 @@ describe('The CardSelector', () => {
     });
 
     // when
-    onKeyDown(({ key } as unknown) as Event);
+    fireEvent.keyDown(window, { key });
 
     // then
     expect(setVote).toHaveBeenCalledWith(selectedCard);
@@ -162,7 +142,7 @@ describe('The CardSelector', () => {
     });
 
     // when
-    onKeyDown(({ key: '3' } as unknown) as Event);
+    fireEvent.keyDown(window, { key: '3' });
 
     // then
     expect(setVote).toHaveBeenCalledWith(VOTE_NOTE_VOTED);
@@ -177,7 +157,7 @@ describe('The CardSelector', () => {
     });
 
     // when
-    onKeyDown(({ key: '1' } as unknown) as Event);
+    fireEvent.keyDown(window, { key: '1' });
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(1, '1');
@@ -186,7 +166,7 @@ describe('The CardSelector', () => {
     rerender({ setVote, state: { votes: { TheUser: '1', OtherUser: '5' } } });
 
     // when
-    onKeyDown(({ key: '1' } as unknown) as Event);
+    fireEvent.keyDown(window, { key: '1' });
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(2, '13');
@@ -195,7 +175,7 @@ describe('The CardSelector', () => {
     rerender({ setVote, state: { votes: { TheUser: '13', OtherUser: '5' } } });
 
     // when
-    onKeyDown(({ key: '1' } as unknown) as Event);
+    fireEvent.keyDown(window, { key: '1' });
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(3, '100');
@@ -207,7 +187,7 @@ describe('The CardSelector', () => {
     });
 
     // when
-    onKeyDown(({ key: '1' } as unknown) as Event);
+    fireEvent.keyDown(window, { key: '1' });
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(4, VOTE_NOTE_VOTED);
@@ -228,7 +208,7 @@ describe('The CardSelector', () => {
     });
 
     // when
-    onKeyDown(({ key: 's' } as unknown) as Event);
+    fireEvent.keyDown(window, { key: 's' });
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(1, 'S');
@@ -243,7 +223,7 @@ describe('The CardSelector', () => {
     });
 
     // when
-    onKeyDown(({ key: 'S' } as unknown) as Event);
+    fireEvent.keyDown(window, { key: 'S' });
 
     // then
     expect(setVote).toHaveBeenNthCalledWith(2, 'S');

--- a/frontend/src/Components/CardSelector.tsx
+++ b/frontend/src/Components/CardSelector.tsx
@@ -38,10 +38,9 @@ function arrayContainsValue<T>(array: T[], value: unknown): value is T {
 const ProtoCardSelector = ({ socket }: { socket: WebSocketApi }) => {
   const selectedCard = socket.state.votes[socket.loginData.user];
 
-  const onKeyDown = (event: KeyboardEvent) => {
-    const keyValue = event.key;
-    if (arrayContainsValue(socket.state.scale, keyValue)) {
-      socket.setVote(keyValue)
+  const onKeyDown = ({ key }: KeyboardEvent) => {
+    if (arrayContainsValue(socket.state.scale, key)) {
+      socket.setVote(key)
     }
   }
 

--- a/frontend/src/Components/CardSelector.tsx
+++ b/frontend/src/Components/CardSelector.tsx
@@ -31,26 +31,27 @@ const getCard = (cardValue: CardValue, isSelected: boolean, setVote: WebSocketAp
   );
 };
 
-function arrayContainsValue<T>(array: T[], value: unknown): value is T {
-  return !!array.find(elem => elem === value)
-}
-
 const ProtoCardSelector = ({ socket }: { socket: WebSocketApi }) => {
   const selectedCard = socket.state.votes[socket.loginData.user];
 
   const onKeyDown = ({ key }: KeyboardEvent) => {
-    if (arrayContainsValue(socket.state.scale, key)) {
-      socket.setVote(key)
+    const matchingCards = socket.state.scale.filter(
+      (card: string) => card[0].toLowerCase() === key.toLowerCase()
+    );
+
+    if (matchingCards.length) {
+      const nextKey = matchingCards[matchingCards.indexOf(selectedCard) + 1] || VOTE_NOTE_VOTED;
+      socket.setVote(nextKey);
     }
-  }
+  };
 
   useEffect(() => {
-    window.addEventListener("keydown", onKeyDown)
+    window.addEventListener('keydown', onKeyDown);
 
     return () => {
-      window.removeEventListener("keydown", onKeyDown);
-    }
-  })
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  });
 
   return (
     <>

--- a/frontend/src/Components/CardSelector.tsx
+++ b/frontend/src/Components/CardSelector.tsx
@@ -36,7 +36,7 @@ const ProtoCardSelector = ({ socket }: { socket: WebSocketApi }) => {
 
   const onKeyDown = ({ key }: KeyboardEvent) => {
     const matchingCards = socket.state.scale.filter(
-      (card: string) => card[0].toLowerCase() === key.toLowerCase()
+      (card) => card[0].toLowerCase() === key.toLowerCase()
     );
 
     if (matchingCards.length) {

--- a/frontend/src/Components/CardSelector.tsx
+++ b/frontend/src/Components/CardSelector.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { useEffect } from 'preact/hooks';
 import { CardValue, WebSocketApi } from '../types/WebSocket';
 import classes from './CardSelector.module.css';
 import { IconCoffee } from './IconCoffee';
@@ -30,8 +31,27 @@ const getCard = (cardValue: CardValue, isSelected: boolean, setVote: WebSocketAp
   );
 };
 
+function arrayContainsValue<T>(array: T[], value: unknown): value is T {
+  return !!array.find(elem => elem === value)
+}
+
 const ProtoCardSelector = ({ socket }: { socket: WebSocketApi }) => {
   const selectedCard = socket.state.votes[socket.loginData.user];
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    const keyValue = event.key;
+    if (arrayContainsValue(socket.state.scale, keyValue)) {
+      socket.setVote(keyValue)
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener("keydown", onKeyDown)
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    }
+  })
 
   return (
     <>


### PR DESCRIPTION
* Add a global event listener to the window that reacts to keydown events
* All the logic is case insensitive
* If the pressed key corresponds to one of the cards in the chosen scale,
the card gets selected
* If the pressed key corresponds to the currently selected card, the next card starting
with the same character gets selected
* If the pressed key corresponds to the currently selected card, and there is no
next card starting with the same character, the card gets unselected
* It is possible to select the `COFFEE` card by pressing `c` or `C`
* It is possible to select the `QUESTION MARK` card by pressing the `?` key. Not likely at all,
but this "feature" comes for free, so there it is
* No option to enable or disable this feature. It is very unlikely to trigger this
feature by accident, but it can also be discovered easily by the user

**EXAMPLE OF THE CYCLING FEATURE:**
Take the `COHEN` scale, which features three cards starting with the character `1`
1. First press of `1` selects the card `1`
2. Second consecutive press of `1` unselects `1` and selects `13`
3. Third consecutive press of `1` unselects `13` and selects `100`
4. Fourth consecutive press of `1` unselects `100`
5. Fifth consecutive press of `1` selects `1` (again)

This is also documented in the unit tests of the `CardSelector` component

**OPEN POINTS:**
* I am very happy to hear suggestions to improve the tests. I did not manage to get them to work using `fireEvent.keydow` :( 