### PR TITLE
Remove ts-jest warning when running tests

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   globals: {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig-test.json',
+      packageJson: 'package.json',
     },
     API_URL: 'wss://api.url',
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "cd frontend && vite",
     "preview": "npm run build:frontend && cd frontend && vite preview",
-    "test": "npx jest --config frontend/jest.config.js",
+    "test": "jest --config frontend/jest.config.js",
     "build": "run-p build:backend build:frontend",
     "lint": "prettier . --write",
     "prepare": "husky install",


### PR DESCRIPTION
* This simple fix removes the annoying warning displayed below:
"ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed."

See https://github.com/kulshekhar/ts-jest/issues/823#issuecomment-515529012