### PR TITLE
Visual refinements for dark mode and imprint

### DIFF
--- a/frontend/src/Components/LegalNoticeContainer/LegalNoticeContainer.tsx
+++ b/frontend/src/Components/LegalNoticeContainer/LegalNoticeContainer.tsx
@@ -1,16 +1,28 @@
-import classes from './LegalNoticeContainer.module.css';
-import { useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { JSXInternal } from 'preact/src/jsx';
 import { LegalNotice } from '../LegalNotice/LegalNotice';
+import classes from './LegalNoticeContainer.module.css';
+
+const MIN_VISIBLE_INITIAL_HEIGHT = 250;
 
 export const LegalNoticeContainer = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const expand = (event: JSXInternal.TargetedMouseEvent<HTMLAnchorElement>) => {
     setIsExpanded(!isExpanded);
     event.preventDefault();
   };
+  useEffect(() => {
+    if (isExpanded && containerRef.current) {
+      const {top} = containerRef.current.getBoundingClientRect();
+      const visibleHeight = (window.innerHeight || document.documentElement.clientHeight) - top
+      if (visibleHeight < MIN_VISIBLE_INITIAL_HEIGHT) {
+        window.scrollBy({top: MIN_VISIBLE_INITIAL_HEIGHT - visibleHeight, behavior: 'smooth'})
+      }
+    }
+  }, [isExpanded]);
   return (
-    <div class={classes.legalNoticeContainer}>
+    <div class={classes.legalNoticeContainer} ref={containerRef}>
       Check&nbsp;
       <a href="#" onClick={expand}>
         privacy&nbsp;notice&nbsp;&amp;&nbsp;imprint


### PR DESCRIPTION
Just two small visual improvements:
* Avoid the smooth transition to dark mode on initial render but switch instantly. This mostly avoids the initial white flash when the preferred color scheme is dark (completely in Chrome, but there is still a short flash in Firefox and Safari, but it could be that those always start with a white page)
* Make sure that when opening the imprint, at least the top part of the imprint is visible and if not, scroll it into view smoothly.