### PR TITLE
Prevent accidental reset

### DIFF
--- a/frontend/src/Components/App/App.test.tsx
+++ b/frontend/src/Components/App/App.test.tsx
@@ -27,6 +27,7 @@ const ConfigureMockWebSocket = () => {
 };
 
 const loginUser = () => {
+  window.confirm = jest.fn().mockReturnValue(true);
   window.history.pushState({}, 'Test Title', '?sessionId=xvdBFRA6FyLZFcKo');
   const socketInstances = ConfigureMockWebSocket();
   const rendered = render(<App />);

--- a/frontend/src/Components/ResetButton/ResetButton.test.tsx
+++ b/frontend/src/Components/ResetButton/ResetButton.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent } from '@testing-library/preact';
+import { BUTTON_RESET_VOTES, BUTTON_CONNECTING } from '../../constants';
+import { getRenderWithWebSocket } from '../../test-helpers/renderWithWebSocket';
+import { ResetButton } from './ResetButton';
+
+const render = getRenderWithWebSocket(<ResetButton />);
+
+describe('The ResetButton', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+  });
+
+  it('disables button if not connected', () => {
+    const { getByRole } = render({
+      connected: false,
+    });
+
+    expect(getByRole('button', { name: BUTTON_CONNECTING })).toBeDisabled();
+  });
+
+  it('enables button if connected', () => {
+    const { getByRole } = render({
+      connected: true,
+    });
+
+    expect(getByRole('button', { name: BUTTON_RESET_VOTES })).toBeEnabled();
+  });
+
+  it('asks the user to confirm on a quick reset', () => {
+    const resetVotes = jest.fn();
+    const confirm = jest.fn().mockReturnValue(true);
+    window.confirm = confirm;
+    const { getByRole } = render({
+      resetVotes,
+    });
+
+    fireEvent.click(getByRole('button'));
+    expect(confirm).toHaveBeenCalled();
+    expect(resetVotes).toHaveBeenCalled();
+  });
+
+  it('does not reset without confirmation', () => {
+    const resetVotes = jest.fn();
+    const confirm = jest.fn().mockReturnValue(false);
+    window.confirm = confirm;
+    const { getByRole } = render({
+      resetVotes,
+    });
+
+    fireEvent.click(getByRole('button'));
+    expect(confirm).toHaveBeenCalled();
+    expect(resetVotes).not.toHaveBeenCalled();
+  });
+
+  it('does not ask the user to confirm after grace period', () => {
+    const resetVotes = jest.fn();
+    const confirm = jest.fn().mockReturnValue(false);
+    window.confirm = confirm;
+    const { getByRole } = render({
+      resetVotes,
+    });
+
+    jest.runOnlyPendingTimers();
+
+    fireEvent.click(getByRole('button'));
+    expect(confirm).not.toHaveBeenCalled();
+    expect(resetVotes).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/Components/ResetButton/ResetButton.tsx
+++ b/frontend/src/Components/ResetButton/ResetButton.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'preact/hooks';
+import { BUTTON_CONNECTING, BUTTON_RESET_VOTES, RESET_VOTES_CONFIRMATION } from '../../constants';
+import sharedClasses from '../../styles.module.css';
+import { connectToWebSocket } from '../WebSocket/WebSocket';
+
+export const ResetButton = connectToWebSocket(({ socket }) => {
+  const locked = useRef<boolean>(true);
+
+  const handleClick = () => {
+    (!locked.current || window.confirm(RESET_VOTES_CONFIRMATION)) && socket.resetVotes();
+  };
+
+  useEffect(() => {
+    setTimeout(() => {
+      locked.current = false;
+    }, 2000);
+  }, []);
+
+  return (
+    <button class={sharedClasses.button} onClick={handleClick} disabled={!socket.connected}>
+      {socket.connected ? BUTTON_RESET_VOTES : BUTTON_CONNECTING}
+    </button>
+  );
+});

--- a/frontend/src/Components/ResultsPage/ResultsPage.tsx
+++ b/frontend/src/Components/ResultsPage/ResultsPage.tsx
@@ -1,17 +1,12 @@
 import { CardValue, VOTE_COFFEE, VOTE_NOTE_VOTED, VOTE_OBSERVER } from '../../../../shared/cards';
 import { Votes } from '../../../../shared/serverMessages';
-import {
-  BUTTON_CONNECTING,
-  BUTTON_RESET_VOTES,
-  COLUMN_NAME,
-  COLUMN_VOTE,
-  HEADING_RESULTS,
-} from '../../constants';
+import { COLUMN_NAME, COLUMN_VOTE, HEADING_RESULTS } from '../../constants';
 import sharedClasses from '../../styles.module.css';
 import { IconCoffee } from '../IconCoffee/IconCoffee';
 import { IconNotVoted } from '../IconNotVoted/IconNotVoted';
 import { IconObserver } from '../IconObserver/IconObserver';
 import { PieChart } from '../PieChart/PieChart';
+import { ResetButton } from '../ResetButton/ResetButton';
 import { connectToWebSocket } from '../WebSocket/WebSocket';
 import { compareVotes } from './compareVotes';
 import classes from './ResultsPage.module.css';
@@ -63,14 +58,6 @@ export const ResultsPage = connectToWebSocket(({ socket }) => (
         </tbody>
       </table>
     </div>
-    <button
-      class={sharedClasses.button}
-      onClick={() => {
-        socket.resetVotes();
-      }}
-      disabled={!socket.connected}
-    >
-      {socket.connected ? BUTTON_RESET_VOTES : BUTTON_CONNECTING}
-    </button>
+    <ResetButton />
   </div>
 ));

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -33,3 +33,5 @@ export const COLUMN_KICK = 'Kick';
 
 export const SWITCH_TO_DARK = 'Switch to dark color mode';
 export const SWITCH_TO_LIGHT = 'Switch to light color mode';
+
+export const RESET_VOTES_CONFIRMATION = 'Do you really want to reset the votes so quickly?';


### PR DESCRIPTION
This PR closed #96 by adding a confirmation dialog if the reset button is pressed within 2 seconds after it being visible in order to prevent accidental reset.

![image](https://user-images.githubusercontent.com/83007010/188895567-1addb37e-e224-46e0-bcfb-3e4e9c9e4e0c.png)