### PR TITLE
Display sizes on results page ordered by size

### DIFF
--- a/frontend/src/Components/ResultsPage/compareVotes.test.ts
+++ b/frontend/src/Components/ResultsPage/compareVotes.test.ts
@@ -1,4 +1,4 @@
-import { CardValue, VOTE_COFFEE, VOTE_NOTE_VOTED } from '../../../../shared/cards';
+import { CardValue, VOTE_COFFEE, VOTE_NOTE_VOTED, VOTE_OBSERVER } from '../../../../shared/cards';
 import { compareCardValues, compareVotes } from './compareVotes';
 
 describe('The compareVotes function', () => {
@@ -14,6 +14,7 @@ describe('The compareVotes function', () => {
         userAndVote2: ['user2', VOTE_NOTE_VOTED],
         result: -1,
       },
+      { userAndVote1: ['user1', 'S'], userAndVote2: ['user2', VOTE_OBSERVER], result: -1 },
     ]
   )(
     'returns $result when $userAndVote1 and $userAndVote2 are passed',
@@ -37,4 +38,20 @@ describe('The compareCardValues function', () => {
     const sortedResults = compareCardValues(value1, value2);
     expect(sortedResults).toEqual(result);
   });
+
+  it.each<{ value1: CardValue; value2: CardValue; result: number }>([
+    { value1: '∞', value2: 'M', result: 1 },
+    { value1: 'S', value2: 'M', result: -1 },
+    { value1: 'XL', value2: VOTE_OBSERVER, result: -1 },
+    { value1: 'XS', value2: 'M', result: -1 },
+    { value1: 'XXL', value2: 'XS', result: 1 },
+    { value1: VOTE_OBSERVER, value2: 'S', result: 1 },
+    { value1: VOTE_COFFEE, value2: 'XL', result: 1 },
+  ])(
+    'returns $result when $value1 and $value2 are passed for sizes',
+    ({ value1, value2, result }) => {
+      const sortedResults = compareCardValues(value1, value2);
+      expect(sortedResults).toEqual(result);
+    }
+  );
 });

--- a/frontend/src/Components/ResultsPage/compareVotes.ts
+++ b/frontend/src/Components/ResultsPage/compareVotes.ts
@@ -1,4 +1,4 @@
-import { CardValue, isSize, SIZES_ORDERED } from '../../../../shared/cards';
+import { ALL_VALUES_ORDERED, CardValue } from '../../../../shared/cards';
 
 export const compareVotes = (
   [user1, value1]: [string, CardValue],
@@ -8,17 +8,7 @@ export const compareVotes = (
 };
 
 export const compareCardValues = (value1: CardValue, value2: CardValue) => {
-  const numericValue1 = isSize(value1) ? SIZES_ORDERED.indexOf(value1) : Number(value1);
-  const numericValue2 = isSize(value2) ? SIZES_ORDERED.indexOf(value2) : Number(value2);
-  if (isNaN(numericValue1) && !isNaN(numericValue2)) return 1;
-  if (!isNaN(numericValue1) && isNaN(numericValue2)) return -1;
-  if (isNaN(numericValue1) && isNaN(numericValue2)) {
-    if (value1.toLowerCase() > value2.toLowerCase()) return 1;
-    if (value1.toLowerCase() < value2.toLowerCase()) return -1;
-  } else {
-    if (numericValue1 > numericValue2) return 1;
-    if (numericValue1 < numericValue2) return -1;
-  }
-
+  if (ALL_VALUES_ORDERED.indexOf(value1) > ALL_VALUES_ORDERED.indexOf(value2)) return 1;
+  if (ALL_VALUES_ORDERED.indexOf(value1) < ALL_VALUES_ORDERED.indexOf(value2)) return -1;
   return 0;
 };

--- a/frontend/src/Components/ResultsPage/compareVotes.ts
+++ b/frontend/src/Components/ResultsPage/compareVotes.ts
@@ -1,4 +1,4 @@
-import { CardValue } from '../../../../shared/cards';
+import { CardValue, isSize, SIZES_ORDERED } from '../../../../shared/cards';
 
 export const compareVotes = (
   [user1, value1]: [string, CardValue],
@@ -8,14 +8,16 @@ export const compareVotes = (
 };
 
 export const compareCardValues = (value1: CardValue, value2: CardValue) => {
-  if (isNaN(Number(value1)) && !isNaN(Number(value2))) return 1;
-  if (!isNaN(Number(value1)) && isNaN(Number(value2))) return -1;
-  if (isNaN(Number(value1)) && isNaN(Number(value2))) {
+  const numericValue1 = isSize(value1) ? SIZES_ORDERED.indexOf(value1) : Number(value1);
+  const numericValue2 = isSize(value2) ? SIZES_ORDERED.indexOf(value2) : Number(value2);
+  if (isNaN(numericValue1) && !isNaN(numericValue2)) return 1;
+  if (!isNaN(numericValue1) && isNaN(numericValue2)) return -1;
+  if (isNaN(numericValue1) && isNaN(numericValue2)) {
     if (value1.toLowerCase() > value2.toLowerCase()) return 1;
     if (value1.toLowerCase() < value2.toLowerCase()) return -1;
   } else {
-    if (Number(value1) > Number(value2)) return 1;
-    if (Number(value1) < Number(value2)) return -1;
+    if (numericValue1 > numericValue2) return 1;
+    if (numericValue1 < numericValue2) return -1;
   }
 
   return 0;

--- a/shared/cards.ts
+++ b/shared/cards.ts
@@ -3,18 +3,17 @@ export const VOTE_COFFEE = 'coffee';
 export const VOTE_OBSERVER = 'observer';
 export const VOTE_NOTE_VOTED = 'not-voted';
 
+export const SIZES_ORDERED = ['XS', 'S', 'M', 'L', 'XL', 'XXL'] as const;
+export const isSize = (card: CardValue): card is typeof SIZES_ORDERED[number] =>
+  SIZES_ORDERED.some((value) => value === card);
+
 export type CardValue =
   | typeof VOTE_OBSERVER
   | typeof VOTE_NOTE_VOTED
   | typeof VOTE_COFFEE
   | '?'
   | '∞'
-  | 'XS'
-  | 'S'
-  | 'M'
-  | 'L'
-  | 'XL'
-  | 'XXL'
+  | typeof SIZES_ORDERED[number]
   | '0'
   | '0.5'
   | '1'

--- a/shared/cards.ts
+++ b/shared/cards.ts
@@ -3,34 +3,40 @@ export const VOTE_COFFEE = 'coffee';
 export const VOTE_OBSERVER = 'observer';
 export const VOTE_NOTE_VOTED = 'not-voted';
 
-export const SIZES_ORDERED = ['XS', 'S', 'M', 'L', 'XL', 'XXL'] as const;
-export const isSize = (card: CardValue): card is typeof SIZES_ORDERED[number] =>
-  SIZES_ORDERED.some((value) => value === card);
+export const SPECIAL_VALUES_ORDERED = ['∞', '?', VOTE_COFFEE] as const;
 
-export type CardValue =
-  | typeof VOTE_OBSERVER
-  | typeof VOTE_NOTE_VOTED
-  | typeof VOTE_COFFEE
-  | '?'
-  | '∞'
-  | typeof SIZES_ORDERED[number]
-  | '0'
-  | '0.5'
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '8'
-  | '13'
-  | '16'
-  | '20'
-  | '21'
-  | '32'
-  | '34'
-  | '40'
-  | '55'
-  | '64'
-  | '89'
-  | '100'
-  | '128';
+const ABSTAINING_VOTES_ORDERED = [VOTE_NOTE_VOTED, VOTE_OBSERVER] as const;
+
+export const SIZES_ORDERED = ['XS', 'S', 'M', 'L', 'XL', 'XXL'] as const;
+
+const NUMERIC_VALUES_ORDERED = [
+  '0',
+  '0.5',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '8',
+  '13',
+  '16',
+  '20',
+  '21',
+  '32',
+  '34',
+  '40',
+  '55',
+  '64',
+  '89',
+  '100',
+  '128',
+] as const;
+
+export const ALL_VALUES_ORDERED = [
+  ...NUMERIC_VALUES_ORDERED,
+  ...SIZES_ORDERED,
+  ...SPECIAL_VALUES_ORDERED,
+  ...ABSTAINING_VOTES_ORDERED,
+] as const;
+
+export type CardValue = typeof ALL_VALUES_ORDERED[number];

--- a/shared/scales.ts
+++ b/shared/scales.ts
@@ -1,19 +1,32 @@
-import { CardValue, SIZES_ORDERED, VOTE_COFFEE } from './cards';
+import { CardValue, SIZES_ORDERED, SPECIAL_VALUES_ORDERED } from './cards';
 
 export type ScaleName = 'FIBONACCI_SCALE' | 'COHEN_SCALE' | 'FIXED_RATIO_SCALE' | 'SIZES_SCALE';
 
 export const SCALES: { [id in ScaleName]: { name: string; values: Array<CardValue> } } = {
   FIBONACCI_SCALE: {
     name: 'Fibonacci',
-    values: [VOTE_COFFEE, '?', '0', '1', '2', '3', '5', '8', '13', '21', '34', '55', '89', '∞'],
+    values: ['0', '1', '2', '3', '5', '8', '13', '21', '34', '55', '89', ...SPECIAL_VALUES_ORDERED],
   },
   COHEN_SCALE: {
     name: 'Cohen',
-    values: [VOTE_COFFEE, '?', '0', '0.5', '1', '2', '3', '5', '8', '13', '20', '40', '100', '∞'],
+    values: [
+      '0',
+      '0.5',
+      '1',
+      '2',
+      '3',
+      '5',
+      '8',
+      '13',
+      '20',
+      '40',
+      '100',
+      ...SPECIAL_VALUES_ORDERED,
+    ],
   },
   FIXED_RATIO_SCALE: {
     name: 'Fixed Ratio',
-    values: [VOTE_COFFEE, '?', '1', '2', '4', '8', '16', '32', '64', '128', '∞'],
+    values: ['1', '2', '4', '8', '16', '32', '64', '128', ...SPECIAL_VALUES_ORDERED],
   },
-  SIZES_SCALE: { name: 'Sizes', values: [VOTE_COFFEE, '?', ...SIZES_ORDERED, '∞'] },
+  SIZES_SCALE: { name: 'Sizes', values: [...SIZES_ORDERED, ...SPECIAL_VALUES_ORDERED] },
 };

--- a/shared/scales.ts
+++ b/shared/scales.ts
@@ -1,4 +1,4 @@
-import { CardValue, VOTE_COFFEE } from './cards';
+import { CardValue, SIZES_ORDERED, VOTE_COFFEE } from './cards';
 
 export type ScaleName = 'FIBONACCI_SCALE' | 'COHEN_SCALE' | 'FIXED_RATIO_SCALE' | 'SIZES_SCALE';
 
@@ -15,5 +15,5 @@ export const SCALES: { [id in ScaleName]: { name: string; values: Array<CardValu
     name: 'Fixed Ratio',
     values: [VOTE_COFFEE, '?', '1', '2', '4', '8', '16', '32', '64', '128', '∞'],
   },
-  SIZES_SCALE: { name: 'Sizes', values: [VOTE_COFFEE, '?', 'XS', 'S', 'M', 'L', 'XL', 'XXL', '∞'] },
+  SIZES_SCALE: { name: 'Sizes', values: [VOTE_COFFEE, '?', ...SIZES_ORDERED, '∞'] },
 };


### PR DESCRIPTION
Previously, the sizes were ordered alphabetically, which resulted in e.g. 'S' being displayed below 'observer'.
Now, they are ordered by their size and displayed above the abstaining votes, same as for the numeric scales.

![Sizes_oredered](https://user-images.githubusercontent.com/101173928/216643095-417e82f2-a0ec-4283-a6a4-cd84eeceed45.png)
