### PR TITLE
E2E tests for session handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ To run all E2E tests via [Playwright](https://playwright.dev), install playwrigh
 npm run e2e
 ```
 
-To work on single E2E tests, run
+Note that this will download a docker image on first run, which may lead to a test timeout. Subsequent runs should work without problems though. If the dev environment is already running, then the tests will reuse it. To work on single E2E tests, run
 
 ```shell
-npm run e2e-ui
+npm run e2e:ui
 ```
 
 which will start the Playwright test runner in UI mode. You can then select the tests you want to run and also watch tests.

--- a/backend/local/socket.ts
+++ b/backend/local/socket.ts
@@ -24,15 +24,19 @@ export const startWebSocketServer = () => {
       tableName: 'scrum-poker-local',
       ddb,
       handler: {
-        postToConnection: (postData: { ConnectionId: string; Data: unknown }) => {
+        postToConnection: ({ ConnectionId, Data }: { ConnectionId: string; Data: unknown }) => {
           const client = [...wss.clients].find(
-            (client) => postData.ConnectionId === (client as WebsocketWithId).id
+            (client) => ConnectionId === (client as WebsocketWithId).id
           );
           const resultPromise = client
             ? new Promise<void>((resolve, reject) =>
-                client.send(postData.Data, (error) => (error ? reject(error) : resolve()))
+                client.send(Data, (error) => (error ? reject(error) : resolve()))
               )
-            : Promise.reject(new Error(`Could not find client with id ${postData.ConnectionId}`));
+            : Promise.reject(
+                Object.assign(new Error(`Could not find client with id ${ConnectionId}`), {
+                  statusCode: 410,
+                })
+              );
           return { promise: () => resultPromise };
         },
       },

--- a/backend/sendmessage/src/login-user.ts
+++ b/backend/sendmessage/src/login-user.ts
@@ -21,7 +21,10 @@ export const loginUser = async (userId: string, groupId: string, config: ConfigW
     : createGroupWithConnection(groupId, userId, getTtl(EXPIRY_TIME_IN_HOUR), config);
 
   const userConnectionId = groupItem?.connections[userId]?.connectionId;
-  if (userConnectionId) {
+  // While it should not be possible to log in while there already is a connection,
+  // this addresses some edge cases observed during local development and makes
+  // it possible to login more liberally.
+  if (userConnectionId && userConnectionId !== config.connectionId) {
     await sendMessageToConnection(
       {
         type: 'not-logged-in',

--- a/backend/sendmessage/src/send-message-to-connection.ts
+++ b/backend/sendmessage/src/send-message-to-connection.ts
@@ -16,13 +16,10 @@ export const sendMessageToConnection = async (
       })
       .promise();
   } catch (e) {
-    if (!(e instanceof Error)) {
-      return;
-    }
-    if ((e as AWSError).statusCode === 410) {
+    if (e && (e as AWSError).statusCode === 410) {
       return removeConnection(config);
     } else {
-      throw e;
+      console.error(`Unexpected error when posting message to connection ${connectionId}:`, e);
     }
   }
 };

--- a/backend/sendmessage/src/send-message-to-connection.ts
+++ b/backend/sendmessage/src/send-message-to-connection.ts
@@ -19,6 +19,8 @@ export const sendMessageToConnection = async (
     if (e && (e as AWSError).statusCode === 410) {
       return removeConnection(config);
     } else {
+      // We do not rethrow the error here because that may prevent other
+      // connections from receiving the message
       console.error(`Unexpected error when posting message to connection ${connectionId}:`, e);
     }
   }

--- a/backend/shared/database/getConnection.ts
+++ b/backend/shared/database/getConnection.ts
@@ -5,4 +5,10 @@ export const getConnection = ({
   connectionId,
   tableName,
   ddb,
-}: Config): Promise<ConnectionItem | void> => getItem('connectionId', connectionId, tableName, ddb);
+}: Config): Promise<ConnectionItem | undefined> => {
+  const connection = getItem<ConnectionItem>('connectionId', connectionId, tableName, ddb);
+  if (!connection) {
+    console.error('No connection found for connectionId', connectionId, connection);
+  }
+  return connection;
+};

--- a/backend/shared/database/getConnection.ts
+++ b/backend/shared/database/getConnection.ts
@@ -8,7 +8,7 @@ export const getConnection = ({
 }: Config): Promise<ConnectionItem | undefined> => {
   const connection = getItem<ConnectionItem>('connectionId', connectionId, tableName, ddb);
   if (!connection) {
-    console.error('No connection found for connectionId', connectionId, connection);
+    console.error('No connection found for connectionId', connectionId);
   }
   return connection;
 };

--- a/backend/shared/database/getItem.ts
+++ b/backend/shared/database/getItem.ts
@@ -5,7 +5,7 @@ export const getItem = async <T>(
   itemId: string,
   tableName: string,
   ddb: DynamoDB.DocumentClient
-): Promise<T | void> =>
+): Promise<T | undefined> =>
   (
     await ddb
       .get({

--- a/e2e/connection-loss.spec.ts
+++ b/e2e/connection-loss.spec.ts
@@ -1,0 +1,86 @@
+import { expect, Page, test } from '@playwright/test';
+import { assertOnCardPage } from './pages/card-page';
+import { login } from './pages/login-page';
+import { assertOnResultsPage } from './pages/results-page';
+
+declare global {
+  interface Window {
+    currentSockets: Set<WebSocket>;
+  }
+}
+
+test('recovers after connection loss due to unexpected close', async ({ page }) => {
+  const { closeSocket } = await instrumentWebSocket(page);
+  await login(page, 'User');
+  const cardPage = await assertOnCardPage(page);
+  await cardPage.selectCard('1');
+  await cardPage.assertVotingStateIs([{ name: 'User', state: 'Voted' }]);
+
+  await closeSocket();
+  await expect(cardPage.revealButton).toHaveText('Connecting…');
+  await expect(cardPage.revealButton).toHaveText('Reveal Votes');
+  await cardPage.selectCard('2');
+  await closeSocket();
+  await expect(cardPage.revealButton).toHaveText('Connecting…');
+  await expect(cardPage.revealButton).toHaveText('Reveal Votes');
+
+  await cardPage.revealButton.click();
+  const resultsPage = await assertOnResultsPage(page);
+  await resultsPage.assertResultsAre([{ name: 'User', result: '2' }]);
+});
+
+test('recovers after connection loss due to error', async ({ page }) => {
+  const { emitError } = await instrumentWebSocket(page);
+  await login(page, 'User');
+  const cardPage = await assertOnCardPage(page);
+  await cardPage.selectCard('1');
+  await cardPage.assertVotingStateIs([{ name: 'User', state: 'Voted' }]);
+
+  await emitError();
+  await expect(cardPage.revealButton).toHaveText('Connecting…');
+  await expect(cardPage.revealButton).toHaveText('Reveal Votes');
+
+  await cardPage.revealButton.click();
+  const resultsPage = await assertOnResultsPage(page);
+  await resultsPage.assertResultsAre([{ name: 'User', result: '1' }]);
+});
+
+async function instrumentWebSocket(page: Page) {
+  await page.addInitScript({
+    content: `const OriginalWebSocket = window.WebSocket;
+      window.currentSockets = new Set();
+      window.WebSocket = class WebSocket extends OriginalWebSocket {
+        constructor(url, ...args) {
+          super(url, ...args);
+          if (url.endsWith(':8080')) {
+            window.currentSockets.add(this);
+            this.addEventListener('close', () => window.currentSockets.delete(this));
+          }
+        }
+      };`,
+  });
+  return {
+    async closeSocket() {
+      expect(
+        await page.evaluate(() => {
+          if (window.currentSockets.size === 1) {
+            const socket = window.currentSockets.values().next().value;
+            socket.close();
+          }
+          return window.currentSockets.size;
+        })
+      ).toBe(1);
+    },
+    async emitError() {
+      expect(
+        await page.evaluate(() => {
+          if (window.currentSockets.size === 1) {
+            const socket: WebSocket = window.currentSockets.values().next().value;
+            socket.dispatchEvent(new Event('error'));
+          }
+          return window.currentSockets.size;
+        })
+      ).toBe(1);
+    },
+  };
+}

--- a/e2e/kicking.spec.ts
+++ b/e2e/kicking.spec.ts
@@ -1,0 +1,16 @@
+import { test } from '@playwright/test';
+import { assertOnCardPage } from './pages/card-page';
+import { assertOnLoginPage, login, loginWithSameSession } from './pages/login-page';
+
+test('allows to kick users', async ({ page, context }) => {
+  await login(page, 'User 1');
+  const secondPage = await context.newPage();
+  await loginWithSameSession(secondPage, 'User 2', page);
+
+  const cardPage = await assertOnCardPage(page);
+  await cardPage.kickUser('User 2');
+  await cardPage.assertVotingStateIs([{ name: 'User 1', state: 'Not voted' }]);
+
+  const secondLoginPage = await assertOnLoginPage(secondPage);
+  await secondLoginPage.assertKickedBy('User 1');
+});

--- a/e2e/pages/card-page.ts
+++ b/e2e/pages/card-page.ts
@@ -35,6 +35,13 @@ export class CardPage {
     );
     await expect(this.votes).toHaveCount(states.length);
   }
+
+  async kickUser(name: string) {
+    const kickButton = this.votes
+      .filter({ has: this.page.locator(`:has-text("${name}")`) })
+      .locator('td:nth-child(3) button');
+    await kickButton.click();
+  }
 }
 
 export const assertOnCardPage = async (page: Page): Promise<CardPage> => {

--- a/e2e/pages/card-page.ts
+++ b/e2e/pages/card-page.ts
@@ -2,7 +2,7 @@ import { expect, Page } from '@playwright/test';
 import { CardValue } from '../../shared/cards';
 
 export class CardPage {
-  readonly revealButton = this.page.getByTestId('reveal-button');
+  readonly revealButton = this.page.getByLabel('reveal votes');
   readonly userName = this.page.getByText(/^Name: .*/);
   readonly votes = this.page.getByRole('table').locator('tbody tr');
   readonly heading = this.page.getByRole('heading');
@@ -36,10 +36,7 @@ export class CardPage {
   }
 
   async kickUser(name: string) {
-    const kickButton = this.votes
-      .filter({ has: this.page.locator(`:has-text("${name}")`) })
-      .locator('td:nth-child(3) button');
-    await kickButton.click();
+    await this.votes.getByTitle(`Kick ${name}`).click();
   }
 }
 

--- a/e2e/pages/card-page.ts
+++ b/e2e/pages/card-page.ts
@@ -2,8 +2,7 @@ import { expect, Page } from '@playwright/test';
 import { CardValue } from '../../shared/cards';
 
 export class CardPage {
-  readonly revealButton = this.page.getByRole('button', { name: 'Reveal Votes' });
-  readonly revealNowButton = this.page.getByRole('button', { name: 'Reveal Now' });
+  readonly revealButton = this.page.getByTestId('reveal-button');
   readonly userName = this.page.getByText(/^Name: .*/);
   readonly votes = this.page.getByRole('table').locator('tbody tr');
   readonly heading = this.page.getByRole('heading');

--- a/e2e/pages/login-page.ts
+++ b/e2e/pages/login-page.ts
@@ -1,13 +1,18 @@
-import { Page } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 
 export class LoginPage {
   readonly nameInput = this.page.getByLabel('Name:');
   readonly loginButton = this.page.getByRole('button', { name: 'Login' });
+  readonly alertText = this.page.getByRole('alert');
 
   constructor(readonly page: Page) {}
 
   async goto() {
     await this.page.goto('/');
+  }
+
+  async assertShown() {
+    await expect(this.loginButton).toBeVisible();
   }
 
   async gotoWithSameSession(otherPage: Page) {
@@ -18,6 +23,16 @@ export class LoginPage {
   async login(name: string) {
     await this.nameInput.fill(name);
     await this.loginButton.click();
+  }
+
+  async assertKickedBy(name: string) {
+    await expect(this.alertText).toHaveText(`You have been kicked by ${name}.`);
+  }
+
+  async assertSessionTakeover() {
+    await expect(this.alertText).toHaveText(
+      'Your session was taken over by another user with the same name.'
+    );
   }
 }
 
@@ -31,4 +46,10 @@ export const loginWithSameSession = async (page: Page, name: string, otherPage: 
   const loginPage = new LoginPage(page);
   await loginPage.gotoWithSameSession(otherPage);
   await loginPage.login(name);
+};
+
+export const assertOnLoginPage = async (page: Page): Promise<LoginPage> => {
+  const loginPage = new LoginPage(page);
+  await loginPage.assertShown();
+  return loginPage;
 };

--- a/e2e/session-takeover.spec.ts
+++ b/e2e/session-takeover.spec.ts
@@ -1,0 +1,28 @@
+import { test } from '@playwright/test';
+import { assertOnCardPage } from './pages/card-page';
+import { assertOnLoginPage, login, loginWithSameSession } from './pages/login-page';
+import { assertOnResultsPage } from './pages/results-page';
+
+test('allows to take over sessions from other users', async ({ page, context }) => {
+  await login(page, 'User');
+  const cardPage = await assertOnCardPage(page);
+  await cardPage.selectCard('1');
+
+  const secondPage = await context.newPage();
+  await loginWithSameSession(secondPage, 'User', page);
+  const secondCardPage = await assertOnCardPage(secondPage);
+  await secondCardPage.assertVotingStateIs([{ name: 'User', state: 'Voted' }]);
+  await secondCardPage.selectCard('2');
+
+  const loginPage = await assertOnLoginPage(page);
+  await loginPage.assertSessionTakeover();
+  await loginPage.login('User');
+  await assertOnCardPage(page);
+  await cardPage.assertVotingStateIs([{ name: 'User', state: 'Voted' }]);
+  await cardPage.revealButton.click();
+  const resultsPage = await assertOnResultsPage(page);
+  await resultsPage.assertResultsAre([{ name: 'User', result: '2' }]);
+
+  const secondLoginPage = await assertOnLoginPage(secondPage);
+  await secondLoginPage.assertSessionTakeover();
+});

--- a/frontend/src/Components/App/App.test.tsx
+++ b/frontend/src/Components/App/App.test.tsx
@@ -21,6 +21,8 @@ const ConfigureMockWebSocket = () => {
     send(message: string) {
       this.test_messages.push(message);
     }
+
+    close() {}
   }
 
   window.WebSocket = MockWebSocket as unknown as typeof window.WebSocket;

--- a/frontend/src/Components/App/App.test.tsx
+++ b/frontend/src/Components/App/App.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render } from '@testing-library/preact';
 import { VOTE_NOTE_VOTED } from '../../../../shared/cards';
 import { SCALES } from '../../../../shared/scales';
 import { ServerMessage } from '../../../../shared/serverMessages';
+import { doNothing } from '../../helpers/helpers';
 import { App } from './App';
 
 const ConfigureMockWebSocket = () => {
@@ -22,7 +23,7 @@ const ConfigureMockWebSocket = () => {
       this.test_messages.push(message);
     }
 
-    close() {}
+    close = doNothing;
   }
 
   window.WebSocket = MockWebSocket as unknown as typeof window.WebSocket;
@@ -132,10 +133,10 @@ describe('The App component', () => {
 
   it('updates, reveals and resets votes and kicks optimistically once the first state message arrived', () => {
     // given
-    const { socket, container, getByRole, getAllByTitle, getByText } = loginUser();
+    const { socket, container, getByRole, getAllByTitle } = loginUser();
 
     // then
-    const revealButton = getByRole('button', { name: 'Connecting…' });
+    const revealButton = getByRole('button', { name: 'reveal votes' });
     expect(revealButton).toBeDisabled();
     container.querySelectorAll('button.largeCard').forEach((card) => expect(card).toBeDisabled());
     getAllByTitle(/^Kick/).forEach((button) => expect(button).toBeDisabled());

--- a/frontend/src/Components/LoginPage/LoginPage.tsx
+++ b/frontend/src/Components/LoginPage/LoginPage.tsx
@@ -39,7 +39,11 @@ export const LoginPage = connectToWebSocket(({ socket }) => {
         socket.login(user, sessionId);
       }}
     >
-      {!!socket.logoutReason && <span class={classes.warning}>{socket.logoutReason}</span>}
+      {!!socket.logoutReason && (
+        <span class={classes.warning} role="alert">
+          {socket.logoutReason}
+        </span>
+      )}
       <div class={classes.heading}>
         {APP_NAME_FIRST}
         <br />

--- a/frontend/src/Components/RevealButton/RevealButton.test.tsx
+++ b/frontend/src/Components/RevealButton/RevealButton.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent } from '@testing-library/preact';
 import { VOTE_NOTE_VOTED, VOTE_OBSERVER } from '../../../../shared/cards';
 import { SCALES } from '../../../../shared/scales';
-import { BUTTON_CONNECTING, BUTTON_REVEAL_NOW, BUTTON_REVEAL_VOTES } from '../../constants';
+import { BUTTON_REVEAL_NOW, BUTTON_REVEAL_VOTES } from '../../constants';
 import { getRenderWithWebSocket } from '../../test-helpers/renderWithWebSocket';
 import { RevealButton } from './RevealButton';
 
@@ -74,7 +74,7 @@ describe('The RevealButton', () => {
       connected: false,
     });
 
-    expect(getByRole('button', { name: BUTTON_CONNECTING })).toBeDisabled();
+    expect(getByRole('button', { name: 'reveal votes' })).toBeDisabled();
   });
 
   it('auto-updates the view and auto-reveals once missing votes have been added', () => {

--- a/frontend/src/Components/RevealButton/RevealButton.tsx
+++ b/frontend/src/Components/RevealButton/RevealButton.tsx
@@ -32,7 +32,12 @@ export const RevealButton = connectToWebSocket(
     const { missing, voted } = getNumberOfVotes(votes);
 
     return (
-      <button class={classes.revealButton} onClick={revealVotes} disabled={!connected || !voted}>
+      <button
+        data-testid="reveal-button"
+        class={classes.revealButton}
+        onClick={revealVotes}
+        disabled={!connected || !voted}
+      >
         {getButtonText({ connected, missing, voted })}
       </button>
     );

--- a/frontend/src/Components/RevealButton/RevealButton.tsx
+++ b/frontend/src/Components/RevealButton/RevealButton.tsx
@@ -33,7 +33,7 @@ export const RevealButton = connectToWebSocket(
 
     return (
       <button
-        data-testid="reveal-button"
+        aria-label="reveal votes"
         class={classes.revealButton}
         onClick={revealVotes}
         disabled={!connected || !voted}

--- a/frontend/src/Components/WebSocket/WebSocket.tsx
+++ b/frontend/src/Components/WebSocket/WebSocket.tsx
@@ -22,8 +22,8 @@ const initialWebSocketState: WebSocketState = {
 };
 
 const initialLoginData: WebSocketLoginData = { user: '', session: '' };
-const baseRetryWait = 200;
-const maxRetryWait = 4000;
+const BASE_RETRY_WAIT = 200;
+const MAX_RETRY_WAIT = 4000;
 
 export const WebSocketContext = createContext<WebSocketApi>({
   connected: false,
@@ -93,7 +93,7 @@ export const WebSocketProvider = ({ children }: { children: ComponentChildren })
       setSocket(null);
       const timeout = setTimeout(
         () => connect(),
-        Math.min(baseRetryWait * 2 ** (reconnectRetries.current++ / 2), maxRetryWait)
+        Math.min(BASE_RETRY_WAIT * 2 ** (reconnectRetries.current++ / 2), MAX_RETRY_WAIT)
       );
       clearReconnectTimeout.current = () => clearTimeout(timeout);
     };

--- a/frontend/src/Components/WebSocket/WebSocket.tsx
+++ b/frontend/src/Components/WebSocket/WebSocket.tsx
@@ -22,6 +22,8 @@ const initialWebSocketState: WebSocketState = {
 };
 
 const initialLoginData: WebSocketLoginData = { user: '', session: '' };
+const baseRetryWait = 200;
+const maxRetryWait = 4000;
 
 export const WebSocketContext = createContext<WebSocketApi>({
   connected: false,
@@ -55,11 +57,14 @@ export const WebSocketProvider = ({ children }: { children: ComponentChildren })
   const [logoutReason, setLogoutReason] = useState<string>();
   const loginDataRef = useRef(loginData);
   const clearReconnectTimeout = useRef<() => void>(doNothing);
+  const reconnectRetries = useRef(0);
   loginDataRef.current = loginData;
 
-  const connect = useCallback((retries = 0) => {
+  const connect = useCallback(() => {
     const webSocket = new WebSocket(WEBSOCKET_URL);
     webSocket.onopen = () => {
+      // After a successful connection, we reset the exponential backoff wait
+      reconnectRetries.current = 0;
       if (loginDataRef.current.user && loginDataRef.current.session) {
         // The login is considered to be "processing" until the server sends a state
         // message. During that time, the user should not be able to trigger backend
@@ -69,6 +74,7 @@ export const WebSocketProvider = ({ children }: { children: ComponentChildren })
       }
       setSocket(webSocket);
     };
+
     webSocket.onmessage = (event: MessageEvent) => {
       const message: ServerMessage = JSON.parse(event.data);
       switch (message.type) {
@@ -82,23 +88,33 @@ export const WebSocketProvider = ({ children }: { children: ComponentChildren })
           console.error(`Unexpected Websocket message ${event.data}`);
       }
     };
+
     webSocket.onclose = () => {
       setSocket(null);
-      const timeout = setTimeout(() => connect(retries + 1), 500 * 2 ** (retries / 2));
-      clearReconnectTimeout.current = () => {
-        clearTimeout(timeout);
-      };
+      const timeout = setTimeout(
+        () => connect(),
+        Math.min(baseRetryWait * 2 ** (reconnectRetries.current++ / 2), maxRetryWait)
+      );
+      clearReconnectTimeout.current = () => clearTimeout(timeout);
     };
 
-    webSocket.onerror = () => {
-      console.error('Unexpected Websocket error.');
+    webSocket.onerror = (error) => {
+      console.error('Unexpected Websocket error', error);
       webSocket.close();
     };
+
+    return webSocket;
   }, []);
 
   useEffect(() => {
-    connect();
-    return clearReconnectTimeout.current;
+    const webSocket = connect();
+    return () => {
+      clearReconnectTimeout.current();
+      // As cleanup, we close the previous socket while ignoring any logic triggered
+      // on close
+      webSocket.onclose = doNothing;
+      webSocket.close();
+    };
   }, [connect]);
 
   const login = (user: string, session: string) => {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:frontend": "cd frontend && vite",
     "start:local-backend": "run-p start:local-backend:db start:local-backend:gateway",
     "start:local-backend:db": "docker start scrumpoker-db || docker run --name scrumpoker-db --rm -p 8000:8000 amazon/dynamodb-local",
-    "start:local-backend:gateway": "nodemon backend/local/main.ts",
+    "start:local-backend:gateway": "nodemon --watch backend backend/local/main.ts",
     "start:local-backend:gateway:ci": "ts-node backend/local/main.ts",
     "preview:frontend": "npm run build:frontend && cd frontend && vite preview",
     "build:backend": "rollup -c backend/rollup.config.ts --configPlugin 'typescript={include:\"backend/rollup.config.ts\"}'",


### PR DESCRIPTION
This extends the E2E test setup with tests for kicking users, taking over sessions and losing connectivity. Losing connectivity is simulated by instrumenting the WebSocket constructor and manually closing the connection or emitting an error.

It also contains some improvements I encountered while working on this:
- The local backend will now add a `statusCode: 410` to the error when a connection is closed so that connections can be cleaned up locally. I hope this works on AWS, i.e. the assumption about the 410 code is correct.
- When any other error is thrown while posting to a connection, it will never be rethrown but logged. This should ensure that messages are not swallowed for some clients.
- A user cannot take over their own session in the backend, i.e. when a user logs in and there already their connection is already registered for that name in the session, they will not kick themselves out immediately. While it should not be possible for this to happen in practice, I encountered it several times when using hot-module-replacement locally.
- When a connection item is not found, then an error is logged as this is always a bug that should not happen.
- The automatic reconnect would never reset its retry counter and did not have a time limit. This meant that when a user is on an unsteady connection, retry attempts will take ages after a while even though the user was connected before. This is improved in two ways:
  - Whenever a connection is established, the retry counter is reset
  - There is an upper limit of 4s for the retry interval
- When unmounting the Websocket, it will now be closed in a way so that it does not attempt to reconnect. This fixes issues when using hot module replacement.
- During development, only changes in the backend folder will now trigger the server to restart.

Furthermore, I added `role: alert` to the red text on the login window and a test-id to the reveal button to make it easy to find them in the tests.