### PR TITLE
Create non-native scale selector

### DIFF
--- a/e2e/basic.spec.ts
+++ b/e2e/basic.spec.ts
@@ -8,6 +8,7 @@ test('syncs state between users', async ({ page, context }) => {
   await login(page, 'User 1');
   const cardPage = await assertOnCardPage(page);
   await cardPage.assertUserNameIs('User 1');
+  await cardPage.assertNoCardSelected();
   await cardPage.assertVotingStateIs([{ name: 'User 1', state: 'Not voted' }]);
 
   // Second login
@@ -15,6 +16,7 @@ test('syncs state between users', async ({ page, context }) => {
   await loginWithSameSession(secondPage, 'User 2', page);
   const secondCardPage = await assertOnCardPage(secondPage);
   await secondCardPage.assertUserNameIs('User 2');
+  await secondCardPage.assertNoCardSelected();
   await secondCardPage.assertVotingStateIs([
     { name: 'User 1', state: 'Not voted' },
     { name: 'User 2', state: 'Not voted' },
@@ -26,6 +28,7 @@ test('syncs state between users', async ({ page, context }) => {
 
   // First vote
   await cardPage.selectCard('1');
+  await cardPage.assertSelectedCardIs('1');
   await cardPage.assertVotingStateIs([
     { name: 'User 2', state: 'Not voted' },
     { name: 'User 1', state: 'Voted' },
@@ -37,6 +40,7 @@ test('syncs state between users', async ({ page, context }) => {
 
   // Second vote
   await secondCardPage.selectCard('40');
+  await secondCardPage.assertSelectedCardIs('40');
   await secondCardPage.assertVotingStateIs([
     { name: 'User 1', state: 'Voted' },
     { name: 'User 2', state: 'Voted' },

--- a/e2e/connection-loss.spec.ts
+++ b/e2e/connection-loss.spec.ts
@@ -39,6 +39,7 @@ test('recovers after connection loss due to error', async ({ page }) => {
   await emitError();
   await expect(cardPage.revealButton).toHaveText('Connecting…');
   await expect(cardPage.revealButton).toHaveText('Reveal Votes');
+  await cardPage.assertSelectedCardIs('1');
 
   await cardPage.revealButton.click();
   const resultsPage = await assertOnResultsPage(page);

--- a/e2e/pages/card-page.ts
+++ b/e2e/pages/card-page.ts
@@ -6,8 +6,34 @@ export class CardPage {
   readonly userName = this.page.getByText(/^Name: .*/);
   readonly votes = this.page.getByRole('table').locator('tbody tr');
   readonly heading = this.page.getByRole('heading');
+  readonly cards = this.page.getByLabel('selectable cards');
+  readonly scaleSelectorButton = this.page.getByRole('button', { name: 'Change Scale' });
+  readonly scaleSelectorDropdown = this.page.getByRole('listbox', { name: 'scales' });
 
   constructor(readonly page: Page) {}
+
+  async assertCardsAre(cards: CardValue[]) {
+    await Promise.all(
+      cards.map(async (card, index) => {
+        await expect(
+          this.cards.getByRole('option').nth(index),
+          `Label of card ${index}`
+        ).toHaveAttribute('aria-label', card);
+      })
+    );
+    await expect(this.cards.getByRole('option')).toHaveCount(cards.length);
+  }
+
+  async assertNoCardSelected() {
+    await expect(this.cards.locator('[aria-selected="true"]')).toHaveCount(0);
+  }
+
+  async assertSelectedCardIs(card: CardValue) {
+    await expect(this.cards.locator(`[aria-label="${card}"]`)).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  }
 
   async assertShown() {
     await expect(this.heading).toHaveText('SELECT A CARD');
@@ -36,7 +62,12 @@ export class CardPage {
   }
 
   async selectCard(value: CardValue) {
-    await this.page.getByRole('button', { name: value, exact: true }).click();
+    await this.cards.locator(`[aria-label="${value}"]`).click();
+  }
+
+  async selectScale(scale: string) {
+    await this.scaleSelectorButton.click();
+    await this.scaleSelectorDropdown.getByRole('option', { name: scale }).click();
   }
 }
 

--- a/e2e/pages/card-page.ts
+++ b/e2e/pages/card-page.ts
@@ -13,10 +13,6 @@ export class CardPage {
     await expect(this.heading).toHaveText('SELECT A CARD');
   }
 
-  async selectCard(value: CardValue) {
-    await this.page.getByRole('button', { name: value, exact: true }).click();
-  }
-
   async assertUserNameIs(name: string) {
     await expect(this.userName).toHaveText(`Name: ${name}`);
   }
@@ -37,6 +33,10 @@ export class CardPage {
 
   async kickUser(name: string) {
     await this.votes.getByTitle(`Kick ${name}`).click();
+  }
+
+  async selectCard(value: CardValue) {
+    await this.page.getByRole('button', { name: value, exact: true }).click();
   }
 }
 

--- a/e2e/scales.spec.ts
+++ b/e2e/scales.spec.ts
@@ -1,0 +1,27 @@
+import { test } from '@playwright/test';
+import { SCALES } from '../shared/scales';
+import { assertOnCardPage } from './pages/card-page';
+import { login, loginWithSameSession } from './pages/login-page';
+
+test('supports changing the scale', async ({ page, context }) => {
+  await login(page, 'User 1');
+  const cardPage = await assertOnCardPage(page);
+  await cardPage.selectCard('1');
+
+  const secondPage = await context.newPage();
+  await loginWithSameSession(secondPage, 'User 2', page);
+  const secondCardPage = await assertOnCardPage(secondPage);
+  await secondCardPage.selectCard('2');
+
+  await cardPage.selectScale('Fibonacci');
+  await cardPage.assertCardsAre([...SCALES.FIBONACCI_SCALE.values, 'observer']);
+  await cardPage.assertNoCardSelected();
+  await secondCardPage.assertCardsAre([...SCALES.FIBONACCI_SCALE.values, 'observer']);
+  await secondCardPage.assertNoCardSelected();
+
+  await secondCardPage.selectScale('Sizes');
+  await secondCardPage.assertCardsAre([...SCALES.SIZES_SCALE.values, 'observer']);
+  await secondCardPage.assertNoCardSelected();
+  await cardPage.assertCardsAre([...SCALES.SIZES_SCALE.values, 'observer']);
+  await cardPage.assertNoCardSelected();
+});

--- a/e2e/session-takeover.spec.ts
+++ b/e2e/session-takeover.spec.ts
@@ -11,6 +11,7 @@ test('allows to take over sessions from other users', async ({ page, context }) 
   const secondPage = await context.newPage();
   await loginWithSameSession(secondPage, 'User', page);
   const secondCardPage = await assertOnCardPage(secondPage);
+  await secondCardPage.assertSelectedCardIs('1');
   await secondCardPage.assertVotingStateIs([{ name: 'User', state: 'Voted' }]);
   await secondCardPage.selectCard('2');
 
@@ -18,6 +19,7 @@ test('allows to take over sessions from other users', async ({ page, context }) 
   await loginPage.assertSessionTakeover();
   await loginPage.login('User');
   await assertOnCardPage(page);
+  await cardPage.assertSelectedCardIs('2');
   await cardPage.assertVotingStateIs([{ name: 'User', state: 'Voted' }]);
   await cardPage.revealButton.click();
   const resultsPage = await assertOnResultsPage(page);

--- a/frontend/src/Components/App/App.test.tsx
+++ b/frontend/src/Components/App/App.test.tsx
@@ -140,7 +140,8 @@ describe('The App component', () => {
     expect(revealButton).toBeDisabled();
     container.querySelectorAll('button.largeCard').forEach((card) => expect(card).toBeDisabled());
     getAllByTitle(/^Kick/).forEach((button) => expect(button).toBeDisabled());
-    expect(getByRole('combobox')).toBeDisabled();
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    expect(changeScaleButton).toBeDisabled();
 
     // when
     act(() =>
@@ -164,7 +165,7 @@ describe('The App component', () => {
     expect(revealButton).toBeEnabled();
     container.querySelectorAll('button.largeCard').forEach((card) => expect(card).toBeEnabled());
     getAllByTitle(/^Kick/).forEach((button) => expect(button).toBeEnabled());
-    expect(getByRole('combobox')).toBeEnabled();
+    expect(changeScaleButton).toBeEnabled();
 
     // when
     const selectedCard = container.querySelectorAll('button.largeCard')[5];

--- a/frontend/src/Components/CardSelector/CardSelector.module.css
+++ b/frontend/src/Components/CardSelector/CardSelector.module.css
@@ -6,6 +6,12 @@
   margin: 0.5rem 0 1rem 0;
 }
 
+.cardCollectionWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .card {
   border: 0.125rem solid var(--primary);
   border-radius: 0.5rem;

--- a/frontend/src/Components/CardSelector/CardSelector.tsx
+++ b/frontend/src/Components/CardSelector/CardSelector.tsx
@@ -13,6 +13,7 @@ const SPECIAL_ICONS: { [value in CardValue]?: JSX.Element } = {
   [VOTE_OBSERVER]: <IconObserver />,
   [VOTE_COFFEE]: <IconCoffee />,
 };
+
 const getCard = (
   cardValue: CardValue,
   isSelected: boolean,
@@ -30,6 +31,9 @@ const getCard = (
         [classes.largeCard]: !isObserver,
         [classes.selected]: isSelected,
       })}
+      aria-selected={isSelected}
+      aria-label={cardValue}
+      role="option"
       onClick={() => setVote(isSelected ? VOTE_NOTE_VOTED : cardValue)}
     >
       {SPECIAL_ICONS[cardValue] || cardValue}
@@ -62,14 +66,14 @@ export const CardSelector = connectToWebSocket(
     });
 
     return (
-      <>
+      <div class={classes.cardCollectionWrapper} role="listbox" aria-label="selectable cards">
         <div class={classes.cardCollection}>
           {state.scale.map((cardValue) =>
             getCard(cardValue, selectedCard === cardValue, setVote, connected)
           )}
         </div>
         {getCard(VOTE_OBSERVER, selectedCard === VOTE_OBSERVER, setVote, connected)}
-      </>
+      </div>
     );
   }
 );

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.module.css
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.module.css
@@ -8,7 +8,6 @@
   width: 100%;
   border-radius: var(--border-radius);
   border: 0.125rem solid var(--primary);
-  box-shadow: 0 0.25rem 0.5rem var(--background);
   margin: 0.25rem 0;
   background-color: var(--background);
   list-style: none;

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.module.css
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.module.css
@@ -9,14 +9,19 @@
   border-radius: var(--border-radius);
   border: 0.125rem solid var(--primary);
   box-shadow: 0 0.25rem 0.5rem var(--background);
-  margin: 0.25rem 0 0;
+  margin: 0.25rem 0;
   background-color: var(--background);
   list-style: none;
   padding: 0.25rem;
 }
 
+.dropDown.onTop {
+  top: unset;
+  bottom: 100%;
+}
+
 .dropDownItem {
-  padding: 0.3rem;
+  padding: 0.25rem;
   cursor: pointer;
 }
 

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.module.css
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.module.css
@@ -8,6 +8,7 @@
   width: 100%;
   border-radius: var(--border-radius);
   border: 0.125rem solid var(--primary);
+  box-shadow: 0 0.25rem 0.5rem var(--background);
   margin: 0.25rem 0 0;
   background-color: var(--background);
   list-style: none;
@@ -19,7 +20,7 @@
   cursor: pointer;
 }
 
-.dropDownItem:hover {
+.dropDownItem[aria-selected='true'] {
   color: var(--text-secondary);
   background: var(--primary-light);
   border-radius: 0.25rem;

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.module.css
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.module.css
@@ -1,5 +1,26 @@
-.select {
-  composes: button from '../../styles.module.css';
-  margin-bottom: 1rem;
-  padding-left: 3.75rem;
+.scaleSelector {
+  position: relative;
+}
+
+.dropDown {
+  position: absolute;
+  top: 100%;
+  width: 100%;
+  border-radius: var(--border-radius);
+  border: 0.125rem solid var(--primary);
+  margin: 0.25rem 0 0;
+  background-color: var(--background);
+  list-style: none;
+  padding: 0.25rem;
+}
+
+.dropDownItem {
+  padding: 0.3rem;
+  cursor: pointer;
+}
+
+.dropDownItem:hover {
+  color: var(--text-secondary);
+  background: var(--primary-light);
+  border-radius: 0.25rem;
 }

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
@@ -76,7 +76,7 @@ describe('The ScaleSelector', () => {
     expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
   });
 
-  it('does not preselect a scale if the scale is does not match', () => {
+  it('does not preselect a scale if the current scale does not match', () => {
     // given
     const { getByRole } = render({
       state: { scale: SCALES.SIZES_SCALE.values.slice(0, -1) },

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
@@ -1,10 +1,4 @@
-import {
-  createEvent,
-  fireEvent,
-  getByRole,
-  queryAllByRole,
-  queryByRole,
-} from '@testing-library/preact';
+import { createEvent, fireEvent, queryAllByRole, screen } from '@testing-library/preact';
 import { VOTE_NOTE_VOTED } from '../../../../shared/cards';
 import { SCALES } from '../../../../shared/scales';
 import { getRenderWithWebSocket } from '../../test-helpers/renderWithWebSocket';
@@ -30,14 +24,14 @@ describe('The ScaleSelector', () => {
 
   it('can be opened to display the list of available scales', () => {
     // given
-    const { container, getByRole } = render();
-    assertDropdownIsClosed(container);
+    const { getByRole } = render();
+    assertDropdownIsClosed();
 
     // when
     fireEvent.click(getByRole('button', { name: 'Change Scale' }));
 
     // then
-    const dropdown = getDropdown(container);
+    const dropdown = getDropdown();
     expect(dropdown.scrollIntoView).toHaveBeenCalledWith({
       behavior: 'smooth',
       block: 'nearest',
@@ -54,19 +48,19 @@ describe('The ScaleSelector', () => {
 
   it('preselects the current scale', () => {
     // given
-    const { container, getByRole } = render({ state: { scale: SCALES.SIZES_SCALE.values } });
+    const { getByRole } = render({ state: { scale: SCALES.SIZES_SCALE.values } });
 
     // when
     fireEvent.click(getByRole('button', { name: 'Change Scale' }));
 
     // then
-    const dropdown = getDropdown(container);
+    const dropdown = getDropdown();
     expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
   });
 
   it('does not preselect a scale if the scale is does not match', () => {
     // given
-    const { container, getByRole } = render({
+    const { getByRole } = render({
       state: { scale: SCALES.SIZES_SCALE.values.slice(0, -1) },
     });
 
@@ -74,14 +68,14 @@ describe('The ScaleSelector', () => {
     fireEvent.click(getByRole('button', { name: 'Change Scale' }));
 
     // then
-    const dropdown = getDropdown(container);
+    const dropdown = getDropdown();
     expect(getSelectedOptions(dropdown)).toEqual([]);
   });
 
   it('allows to select a scale', () => {
     // given
     const setScale = jest.fn();
-    const { container, getByRole, getByText } = render({ setScale });
+    const { getByRole, getByText } = render({ setScale });
 
     // when
     fireEvent.click(getByRole('button', { name: 'Change Scale' }));
@@ -89,13 +83,13 @@ describe('The ScaleSelector', () => {
 
     // then
     expect(setScale).toHaveBeenCalledWith(SCALES.SIZES_SCALE.values);
-    assertDropdownIsClosed(container);
+    assertDropdownIsClosed();
   });
 
   it('supports keyboard navigation', () => {
     // given
     const setScale = jest.fn();
-    const { container, getByRole } = render({ setScale });
+    const { getByRole } = render({ setScale });
 
     // when
     // As this is a real button, we cannot use synthetic events to trigger it
@@ -103,7 +97,7 @@ describe('The ScaleSelector', () => {
     fireEvent.click(changeScaleButton);
 
     // then
-    const dropdown = getDropdown(container);
+    const dropdown = getDropdown();
     expect(getSelectedOptions(dropdown)).toEqual(['Cohen']);
 
     fireEvent.keyDown(dropdown, { code: 'ArrowDown' });
@@ -138,36 +132,36 @@ describe('The ScaleSelector', () => {
     fireEvent(dropdown, keyDownEnterEvent);
     expect(keyDownEnterEvent.defaultPrevented).toBe(true);
     expect(setScale).toHaveBeenCalledWith(SCALES.SIZES_SCALE.values);
-    assertDropdownIsClosed(container);
+    assertDropdownIsClosed();
     expect(changeScaleButton).toHaveFocus();
   });
 
   it('supports selecting an element via space key', () => {
     // given
     const setScale = jest.fn();
-    const { container, getByRole } = render({ setScale });
+    const { getByRole } = render({ setScale });
 
     // when
     const changeScaleButton = getByRole('button', { name: 'Change Scale' });
     fireEvent.click(changeScaleButton);
-    const dropdown = getDropdown(container);
+    const dropdown = getDropdown();
     fireEvent.keyDown(dropdown, { code: 'Space' });
 
     // then
     expect(setScale).toHaveBeenCalledWith(SCALES.COHEN_SCALE.values);
-    assertDropdownIsClosed(container);
+    assertDropdownIsClosed();
     expect(changeScaleButton).toHaveFocus();
   });
 
   it('combines mouse and keyboard selection', () => {
     // given
     const setScale = jest.fn();
-    const { container, getByRole, getByText } = render({ setScale });
+    const { getByRole, getByText } = render({ setScale });
 
     // when
     const changeScaleButton = getByRole('button', { name: 'Change Scale' });
     fireEvent.click(changeScaleButton);
-    const dropdown = getDropdown(container);
+    const dropdown = getDropdown();
 
     // then
     fireEvent.mouseMove(getByText('Sizes'));
@@ -185,49 +179,49 @@ describe('The ScaleSelector', () => {
 
     fireEvent.keyDown(dropdown, { code: 'Enter' });
     expect(setScale).toHaveBeenCalledWith(SCALES.COHEN_SCALE.values);
-    assertDropdownIsClosed(container);
+    assertDropdownIsClosed();
     expect(changeScaleButton).toHaveFocus();
   });
 
   it('closes the popup without selection when enter is pressed without a selected item', () => {
     // given
     const setScale = jest.fn();
-    const { container, getByRole, getByText } = render({ setScale });
+    const { getByRole, getByText } = render({ setScale });
 
     // when
     const changeScaleButton = getByRole('button', { name: 'Change Scale' });
     fireEvent.click(changeScaleButton);
-    const dropdown = getDropdown(container);
+    const dropdown = getDropdown();
     fireEvent.mouseMove(getByText('Fibonacci'));
     fireEvent.mouseLeave(getByText('Fibonacci'));
     fireEvent.keyDown(dropdown, { code: 'Enter' });
 
     // then
     expect(setScale).not.toHaveBeenCalled();
-    assertDropdownIsClosed(container);
+    assertDropdownIsClosed();
     expect(changeScaleButton).toHaveFocus();
   });
 
   it('closes the popup without selection when escape is pressed', () => {
     // given
     const setScale = jest.fn();
-    const { container, getByRole } = render({ setScale });
+    const { getByRole } = render({ setScale });
 
     // when
     const changeScaleButton = getByRole('button', { name: 'Change Scale' });
     fireEvent.click(changeScaleButton);
-    const dropdown = getDropdown(container);
+    const dropdown = getDropdown();
     fireEvent.keyDown(dropdown, { code: 'Escape' });
 
     // then
     expect(setScale).not.toHaveBeenCalled();
-    assertDropdownIsClosed(container);
+    assertDropdownIsClosed();
     expect(changeScaleButton).toHaveFocus();
   });
 
   it('closes the popup when clicking the button again', () => {
     // given
-    const { container, getByRole } = render();
+    const { getByRole } = render();
 
     // when
     const changeScaleButton = getByRole('button', { name: 'Change Scale' });
@@ -235,12 +229,12 @@ describe('The ScaleSelector', () => {
     fireEvent.click(changeScaleButton);
 
     // then
-    assertDropdownIsClosed(container);
+    assertDropdownIsClosed();
   });
 
   it('closes the popup and disables the button when the connection is lost', () => {
     // given
-    const { container, getByRole, rerender } = render();
+    const { getByRole, rerender } = render();
 
     // when
     const changeScaleButton = getByRole('button', { name: 'Change Scale' });
@@ -248,38 +242,38 @@ describe('The ScaleSelector', () => {
     rerender({ connected: false });
 
     // then
-    assertDropdownIsClosed(container);
+    assertDropdownIsClosed();
     expect(changeScaleButton).toBeDisabled();
 
     // when
     rerender({ connected: true });
 
     // then
-    assertDropdownIsClosed(container);
+    assertDropdownIsClosed();
     expect(changeScaleButton).toBeEnabled();
   });
 
   it('closes the popup when focus is lost', () => {
     // given
-    const { container, getByRole } = render();
+    const { getByRole } = render();
 
     // when
     const changeScaleButton = getByRole('button', { name: 'Change Scale' });
     fireEvent.click(changeScaleButton);
-    fireEvent.blur(getDropdown(container));
+    fireEvent.blur(getDropdown());
 
     // then
-    assertDropdownIsClosed(container);
+    assertDropdownIsClosed();
   });
 
   it('does not close the popup when focus is lost to the button', () => {
     // given
-    const { container, getByRole } = render();
+    const { getByRole } = render();
 
     // when
     const changeScaleButton = getByRole('button', { name: 'Change Scale' });
     fireEvent.click(changeScaleButton);
-    const dropdown = getDropdown(container);
+    const dropdown = getDropdown();
     fireEvent.blur(dropdown, { relatedTarget: changeScaleButton });
     fireEvent.blur(changeScaleButton, { relatedTarget: dropdown });
 
@@ -288,10 +282,10 @@ describe('The ScaleSelector', () => {
   });
 });
 
-const assertDropdownIsClosed = (container: HTMLElement) =>
-  expect(queryByRole(container, 'listbox', { name: 'scales' })).toBeNull();
+const assertDropdownIsClosed = () =>
+  expect(screen.queryByRole('listbox', { name: 'scales' })).not.toBeInTheDocument();
 
-const getDropdown = (container: HTMLElement) => getByRole(container, 'listbox', { name: 'scales' });
+const getDropdown = () => screen.getByRole('listbox', { name: 'scales' });
 
 const getSelectedOptions = (container: HTMLElement) =>
   queryAllByRole(container, 'option')

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
@@ -1,0 +1,275 @@
+import {
+  createEvent,
+  fireEvent,
+  getByRole,
+  queryAllByRole,
+  queryByRole,
+} from '@testing-library/preact';
+import { VOTE_NOTE_VOTED } from '../../../../shared/cards';
+import { SCALES } from '../../../../shared/scales';
+import { getRenderWithWebSocket } from '../../test-helpers/renderWithWebSocket';
+import { ScaleSelector } from './ScaleSelector';
+
+const render = getRenderWithWebSocket(<ScaleSelector />, {
+  connected: true,
+  loginData: { user: 'TheUser', session: 'TheSession123456' },
+  loggedIn: true,
+  state: {
+    resultsVisible: false,
+    votes: {
+      TheUser: VOTE_NOTE_VOTED,
+    },
+    scale: SCALES.COHEN_SCALE.values,
+  },
+});
+
+describe('The ScaleSelector', () => {
+  beforeEach(() => {
+    HTMLUListElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  it('can be opened to display the list of available scales', () => {
+    // given
+    const { container, getByRole } = render();
+    assertDropdownIsClosed(container);
+
+    // when
+    fireEvent.click(getByRole('button', { name: 'Change Scale' }));
+
+    // then
+    const dropdown = getDropdown(container);
+    expect(dropdown.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'nearest',
+    });
+    expect(dropdown).toHaveFocus();
+    expect(queryAllByRole(dropdown, 'option').map((option) => option.textContent)).toEqual([
+      'Fibonacci',
+      'Cohen',
+      'Fixed Ratio',
+      'Sizes',
+    ]);
+  });
+
+  it('allows to select a scale', () => {
+    // given
+    const setScale = jest.fn();
+    const { container, getByRole, getByText } = render({ setScale });
+
+    // when
+    fireEvent.click(getByRole('button', { name: 'Change Scale' }));
+    fireEvent.click(getByText('Sizes'));
+
+    // then
+    expect(setScale).toHaveBeenCalledWith(SCALES.SIZES_SCALE.values);
+    assertDropdownIsClosed(container);
+  });
+
+  it('supports keyboard navigation', () => {
+    // given
+    const setScale = jest.fn();
+    const { container, getByRole } = render({ setScale });
+
+    // when
+    // As this is a real button, we cannot use synthetic events to trigger it
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    fireEvent.click(changeScaleButton);
+
+    // then
+    const dropdown = getDropdown(container);
+    expect(getSelectedOptions(dropdown)).toEqual(['Fibonacci']);
+
+    fireEvent.keyDown(dropdown, { key: 'ArrowDown' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Cohen']);
+
+    fireEvent.keyDown(dropdown, { key: 'ArrowDown' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Fixed Ratio']);
+
+    fireEvent.keyDown(dropdown, { key: 'ArrowDown' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
+
+    fireEvent.keyDown(dropdown, { key: 'ArrowDown' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Fibonacci']);
+
+    fireEvent.keyDown(dropdown, { key: 'ArrowUp' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
+
+    fireEvent.keyDown(dropdown, { key: 'ArrowUp' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Fixed Ratio']);
+
+    fireEvent.keyDown(dropdown, { key: 'PageUp' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Fibonacci']);
+
+    fireEvent.keyDown(dropdown, { key: 'PageDown' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
+
+    fireEvent.keyDown(dropdown, { key: 'Home' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Fibonacci']);
+
+    fireEvent.keyDown(dropdown, { key: 'End' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
+
+    expect(setScale).not.toHaveBeenCalled();
+    const keyDownEnterEvent = createEvent.keyDown(dropdown, { key: 'Enter' });
+    fireEvent(dropdown, keyDownEnterEvent);
+    expect(keyDownEnterEvent.defaultPrevented).toBe(true);
+    expect(setScale).toHaveBeenCalledWith(SCALES.SIZES_SCALE.values);
+    assertDropdownIsClosed(container);
+    expect(changeScaleButton).toHaveFocus();
+  });
+
+  it('supports selecting an element via space key', () => {
+    // given
+    const setScale = jest.fn();
+    const { container, getByRole } = render({ setScale });
+
+    // when
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    fireEvent.click(changeScaleButton);
+    const dropdown = getDropdown(container);
+    fireEvent.keyDown(dropdown, { key: ' ' });
+
+    // then
+    expect(setScale).toHaveBeenCalledWith(SCALES.FIBONACCI_SCALE.values);
+    assertDropdownIsClosed(container);
+    expect(changeScaleButton).toHaveFocus();
+  });
+
+  it('combines mouse and keyboard selection', () => {
+    // given
+    const setScale = jest.fn();
+    const { container, getByRole, getByText } = render({ setScale });
+
+    // when
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    fireEvent.click(changeScaleButton);
+    const dropdown = getDropdown(container);
+
+    // then
+    fireEvent.mouseMove(getByText('Sizes'));
+    expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
+
+    fireEvent.keyDown(dropdown, { key: 'ArrowUp' });
+    expect(getSelectedOptions(dropdown)).toEqual(['Fixed Ratio']);
+
+    fireEvent.mouseMove(getByText('Sizes'));
+    fireEvent.mouseLeave(getByText('Sizes'));
+    expect(getSelectedOptions(dropdown)).toEqual([]);
+
+    fireEvent.mouseMove(getByText('Cohen'));
+    expect(getSelectedOptions(dropdown)).toEqual(['Cohen']);
+
+    fireEvent.keyDown(dropdown, { key: 'Enter' });
+    expect(setScale).toHaveBeenCalledWith(SCALES.COHEN_SCALE.values);
+    assertDropdownIsClosed(container);
+    expect(changeScaleButton).toHaveFocus();
+  });
+
+  it('closes the popup without selection when enter is pressed without a selected item', () => {
+    // given
+    const setScale = jest.fn();
+    const { container, getByRole, getByText } = render({ setScale });
+
+    // when
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    fireEvent.click(changeScaleButton);
+    const dropdown = getDropdown(container);
+    fireEvent.mouseMove(getByText('Fibonacci'));
+    fireEvent.mouseLeave(getByText('Fibonacci'));
+    fireEvent.keyDown(dropdown, { key: 'Enter' });
+
+    // then
+    expect(setScale).not.toHaveBeenCalled();
+    assertDropdownIsClosed(container);
+    expect(changeScaleButton).toHaveFocus();
+  });
+
+  it('closes the popup without selection when escape is pressed', () => {
+    // given
+    const setScale = jest.fn();
+    const { container, getByRole } = render({ setScale });
+
+    // when
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    fireEvent.click(changeScaleButton);
+    const dropdown = getDropdown(container);
+    fireEvent.keyDown(dropdown, { key: 'Escape' });
+
+    // then
+    expect(setScale).not.toHaveBeenCalled();
+    assertDropdownIsClosed(container);
+    expect(changeScaleButton).toHaveFocus();
+  });
+
+  it('closes the popup when clicking the button again', () => {
+    // given
+    const { container, getByRole } = render();
+
+    // when
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    fireEvent.click(changeScaleButton);
+    fireEvent.click(changeScaleButton);
+
+    // then
+    assertDropdownIsClosed(container);
+  });
+
+  it('closes the popup and disables the button when the connection is lost', () => {
+    // given
+    const { container, getByRole, rerender } = render();
+
+    // when
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    fireEvent.click(changeScaleButton);
+    rerender({ connected: false });
+
+    // then
+    assertDropdownIsClosed(container);
+    expect(changeScaleButton).toBeDisabled();
+
+    // when
+    rerender({ connected: true });
+
+    // then
+    assertDropdownIsClosed(container);
+    expect(changeScaleButton).toBeEnabled();
+  });
+
+  it('closes the popup when focus is lost', () => {
+    // given
+    const { container, getByRole } = render();
+
+    // when
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    fireEvent.click(changeScaleButton);
+    fireEvent.blur(getDropdown(container));
+
+    // then
+    assertDropdownIsClosed(container);
+  });
+
+  it('does not close the popup when focus is lost to the button', () => {
+    // given
+    const { container, getByRole } = render();
+
+    // when
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    fireEvent.click(changeScaleButton);
+    const dropdown = getDropdown(container);
+    fireEvent.blur(dropdown, { relatedTarget: changeScaleButton });
+    fireEvent.blur(changeScaleButton, { relatedTarget: dropdown });
+
+    // then
+    expect(dropdown).toBeVisible();
+  });
+});
+
+const assertDropdownIsClosed = (container: HTMLElement) =>
+  expect(queryByRole(container, 'listbox', { name: 'scales' })).toBeNull();
+
+const getDropdown = (container: HTMLElement) => getByRole(container, 'listbox', { name: 'scales' });
+
+const getSelectedOptions = (container: HTMLElement) =>
+  queryAllByRole(container, 'option')
+    .filter((option) => option.getAttribute('aria-selected') === 'true')
+    .map((option) => option.textContent);

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
@@ -49,6 +49,33 @@ describe('The ScaleSelector', () => {
       'Fixed Ratio',
       'Sizes',
     ]);
+    expect(getSelectedOptions(dropdown)).toEqual(['Cohen']);
+  });
+
+  it('preselects the current scale', () => {
+    // given
+    const { container, getByRole } = render({ state: { scale: SCALES.SIZES_SCALE.values } });
+
+    // when
+    fireEvent.click(getByRole('button', { name: 'Change Scale' }));
+
+    // then
+    const dropdown = getDropdown(container);
+    expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
+  });
+
+  it('does not preselect a scale if the scale is does not match', () => {
+    // given
+    const { container, getByRole } = render({
+      state: { scale: SCALES.SIZES_SCALE.values.slice(0, -1) },
+    });
+
+    // when
+    fireEvent.click(getByRole('button', { name: 'Change Scale' }));
+
+    // then
+    const dropdown = getDropdown(container);
+    expect(getSelectedOptions(dropdown)).toEqual([]);
   });
 
   it('allows to select a scale', () => {
@@ -77,9 +104,6 @@ describe('The ScaleSelector', () => {
 
     // then
     const dropdown = getDropdown(container);
-    expect(getSelectedOptions(dropdown)).toEqual(['Fibonacci']);
-
-    fireEvent.keyDown(dropdown, { code: 'ArrowDown' });
     expect(getSelectedOptions(dropdown)).toEqual(['Cohen']);
 
     fireEvent.keyDown(dropdown, { code: 'ArrowDown' });
@@ -130,7 +154,7 @@ describe('The ScaleSelector', () => {
     fireEvent.keyDown(dropdown, { code: 'Space' });
 
     // then
-    expect(setScale).toHaveBeenCalledWith(SCALES.FIBONACCI_SCALE.values);
+    expect(setScale).toHaveBeenCalledWith(SCALES.COHEN_SCALE.values);
     assertDropdownIsClosed(container);
     expect(changeScaleButton).toHaveFocus();
   });

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
@@ -28,14 +28,16 @@ describe('The ScaleSelector', () => {
     assertDropdownIsClosed();
 
     // when
-    fireEvent.click(getByRole('button', { name: 'Change Scale' }));
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    changeScaleButton.getBoundingClientRect = () =>
+      ({
+        bottom: window.innerHeight - 500,
+      } as DOMRect);
+    fireEvent.click(changeScaleButton);
 
     // then
     const dropdown = getDropdown();
-    expect(dropdown.scrollIntoView).toHaveBeenCalledWith({
-      behavior: 'smooth',
-      block: 'nearest',
-    });
+    expect(dropdown).not.toHaveClass('onTop');
     expect(dropdown).toHaveFocus();
     expect(queryAllByRole(dropdown, 'option').map((option) => option.textContent)).toEqual([
       'Fibonacci',
@@ -44,6 +46,22 @@ describe('The ScaleSelector', () => {
       'Sizes',
     ]);
     expect(getSelectedOptions(dropdown)).toEqual(['Cohen']);
+  });
+
+  it('opens to the top if there is not enough space below', () => {
+    // given
+    const { getByRole } = render();
+
+    // when
+    const changeScaleButton = getByRole('button', { name: 'Change Scale' });
+    changeScaleButton.getBoundingClientRect = () =>
+      ({
+        bottom: window.innerHeight,
+      } as DOMRect);
+    fireEvent.click(changeScaleButton);
+
+    // then
+    expect(getDropdown()).toHaveClass('onTop');
   });
 
   it('preselects the current scale', () => {

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.test.tsx
@@ -79,38 +79,38 @@ describe('The ScaleSelector', () => {
     const dropdown = getDropdown(container);
     expect(getSelectedOptions(dropdown)).toEqual(['Fibonacci']);
 
-    fireEvent.keyDown(dropdown, { key: 'ArrowDown' });
+    fireEvent.keyDown(dropdown, { code: 'ArrowDown' });
     expect(getSelectedOptions(dropdown)).toEqual(['Cohen']);
 
-    fireEvent.keyDown(dropdown, { key: 'ArrowDown' });
+    fireEvent.keyDown(dropdown, { code: 'ArrowDown' });
     expect(getSelectedOptions(dropdown)).toEqual(['Fixed Ratio']);
 
-    fireEvent.keyDown(dropdown, { key: 'ArrowDown' });
+    fireEvent.keyDown(dropdown, { code: 'ArrowDown' });
     expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
 
-    fireEvent.keyDown(dropdown, { key: 'ArrowDown' });
+    fireEvent.keyDown(dropdown, { code: 'ArrowDown' });
     expect(getSelectedOptions(dropdown)).toEqual(['Fibonacci']);
 
-    fireEvent.keyDown(dropdown, { key: 'ArrowUp' });
+    fireEvent.keyDown(dropdown, { code: 'ArrowUp' });
     expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
 
-    fireEvent.keyDown(dropdown, { key: 'ArrowUp' });
+    fireEvent.keyDown(dropdown, { code: 'ArrowUp' });
     expect(getSelectedOptions(dropdown)).toEqual(['Fixed Ratio']);
 
-    fireEvent.keyDown(dropdown, { key: 'PageUp' });
+    fireEvent.keyDown(dropdown, { code: 'PageUp' });
     expect(getSelectedOptions(dropdown)).toEqual(['Fibonacci']);
 
-    fireEvent.keyDown(dropdown, { key: 'PageDown' });
+    fireEvent.keyDown(dropdown, { code: 'PageDown' });
     expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
 
-    fireEvent.keyDown(dropdown, { key: 'Home' });
+    fireEvent.keyDown(dropdown, { code: 'Home' });
     expect(getSelectedOptions(dropdown)).toEqual(['Fibonacci']);
 
-    fireEvent.keyDown(dropdown, { key: 'End' });
+    fireEvent.keyDown(dropdown, { code: 'End' });
     expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
 
     expect(setScale).not.toHaveBeenCalled();
-    const keyDownEnterEvent = createEvent.keyDown(dropdown, { key: 'Enter' });
+    const keyDownEnterEvent = createEvent.keyDown(dropdown, { code: 'Enter' });
     fireEvent(dropdown, keyDownEnterEvent);
     expect(keyDownEnterEvent.defaultPrevented).toBe(true);
     expect(setScale).toHaveBeenCalledWith(SCALES.SIZES_SCALE.values);
@@ -127,7 +127,7 @@ describe('The ScaleSelector', () => {
     const changeScaleButton = getByRole('button', { name: 'Change Scale' });
     fireEvent.click(changeScaleButton);
     const dropdown = getDropdown(container);
-    fireEvent.keyDown(dropdown, { key: ' ' });
+    fireEvent.keyDown(dropdown, { code: 'Space' });
 
     // then
     expect(setScale).toHaveBeenCalledWith(SCALES.FIBONACCI_SCALE.values);
@@ -149,7 +149,7 @@ describe('The ScaleSelector', () => {
     fireEvent.mouseMove(getByText('Sizes'));
     expect(getSelectedOptions(dropdown)).toEqual(['Sizes']);
 
-    fireEvent.keyDown(dropdown, { key: 'ArrowUp' });
+    fireEvent.keyDown(dropdown, { code: 'ArrowUp' });
     expect(getSelectedOptions(dropdown)).toEqual(['Fixed Ratio']);
 
     fireEvent.mouseMove(getByText('Sizes'));
@@ -159,7 +159,7 @@ describe('The ScaleSelector', () => {
     fireEvent.mouseMove(getByText('Cohen'));
     expect(getSelectedOptions(dropdown)).toEqual(['Cohen']);
 
-    fireEvent.keyDown(dropdown, { key: 'Enter' });
+    fireEvent.keyDown(dropdown, { code: 'Enter' });
     expect(setScale).toHaveBeenCalledWith(SCALES.COHEN_SCALE.values);
     assertDropdownIsClosed(container);
     expect(changeScaleButton).toHaveFocus();
@@ -176,7 +176,7 @@ describe('The ScaleSelector', () => {
     const dropdown = getDropdown(container);
     fireEvent.mouseMove(getByText('Fibonacci'));
     fireEvent.mouseLeave(getByText('Fibonacci'));
-    fireEvent.keyDown(dropdown, { key: 'Enter' });
+    fireEvent.keyDown(dropdown, { code: 'Enter' });
 
     // then
     expect(setScale).not.toHaveBeenCalled();
@@ -193,7 +193,7 @@ describe('The ScaleSelector', () => {
     const changeScaleButton = getByRole('button', { name: 'Change Scale' });
     fireEvent.click(changeScaleButton);
     const dropdown = getDropdown(container);
-    fireEvent.keyDown(dropdown, { key: 'Escape' });
+    fireEvent.keyDown(dropdown, { code: 'Escape' });
 
     // then
     expect(setScale).not.toHaveBeenCalled();

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
@@ -45,7 +45,7 @@ export const ScaleSelector = connectToWebSocket(
       if (open) {
         close();
       } else {
-        setSelected(availableScales.findIndex(isScaleSelected(scale)) || 0);
+        setSelected(availableScales.findIndex(getScaleMatcher(scale)));
         updateDropdownPosition();
         setOpen(true);
       }
@@ -158,7 +158,7 @@ export const ScaleSelector = connectToWebSocket(
 const unsignedModulo = (dividend: number, divisor: number) =>
   ((dividend % divisor) + divisor) % divisor;
 
-const isScaleSelected =
+const getScaleMatcher =
   (currentScale: CardValue[]) =>
   ([, { values }]: typeof availableScales[number]) =>
     values.length === currentScale.length &&

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
@@ -34,7 +34,7 @@ export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale
   };
 
   const handleKeyboardNavigation = (event: KeyboardEvent) => {
-    switch (event.key) {
+    switch (event.code) {
       case 'ArrowDown':
         setSelected((selected + 1) % availableScales.length);
         event.preventDefault();
@@ -56,7 +56,7 @@ export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale
         selectionButtonRef.current?.focus();
         break;
       case 'Enter':
-      case ' ':
+      case 'Space':
         // Prevent "enter" from triggering the button if the dropdown is open
         event.preventDefault();
         close();

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
@@ -22,6 +22,7 @@ export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale
     if (open) {
       close();
     } else {
+      setSelected(0);
       setOpen(true);
     }
   };
@@ -42,20 +43,35 @@ export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale
         setSelected((Math.max(selected, 0) + availableScales.length - 1) % availableScales.length);
         event.preventDefault();
         break;
+      case 'Home':
+      case 'PageUp':
+        setSelected(0);
+        break;
+      case 'End':
+      case 'PageDown':
+        setSelected(availableScales.length - 1);
+        break;
+      case 'Escape':
+        close();
+        selectionButtonRef.current?.focus();
+        break;
       case 'Enter':
       case ' ':
         // Prevent "enter" from triggering the button if the dropdown is open
         event.preventDefault();
+        close();
+        selectionButtonRef.current?.focus();
         if (selected >= 0) {
-          close();
           setScale(availableScales[selected][1].values);
-          selectionButtonRef.current?.focus();
         }
+        break;
     }
   };
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      return;
+    }
     if (!connected) {
       close();
       return;

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { CardValue } from '../../../../shared/cards';
 import { ScaleName, SCALES } from '../../../../shared/scales';
@@ -7,6 +8,10 @@ import { connectToWebSocket } from '../WebSocket/WebSocket';
 import classes from './ScaleSelector.module.css';
 
 const availableScales = Object.entries(SCALES);
+const DROPDOWN_HEIGHT =
+  Object.keys(SCALES).length * (18.5 /*height*/ + /*padding*/ 8) +
+  /*outer padding and border*/ 12 +
+  /*distance to button*/ 4;
 
 export const ScaleSelector = connectToWebSocket(
   ({
@@ -18,8 +23,18 @@ export const ScaleSelector = connectToWebSocket(
   }) => {
     const [open, setOpen] = useState(false);
     const [selected, setSelected] = useState(-1);
+    const [dropdownOnTop, setDropdownOnTop] = useState(false);
     const selectionButtonRef = useRef<HTMLButtonElement>(null);
     const dropdownRef = useRef<HTMLUListElement>(null);
+
+    const updateDropdownPosition = () => {
+      if (selectionButtonRef.current) {
+        setDropdownOnTop(
+          selectionButtonRef.current.getBoundingClientRect().bottom + DROPDOWN_HEIGHT >
+            window.innerHeight
+        );
+      }
+    };
 
     const close = () => {
       setOpen(false);
@@ -31,6 +46,7 @@ export const ScaleSelector = connectToWebSocket(
         close();
       } else {
         setSelected(availableScales.findIndex(isScaleSelected(scale)) || 0);
+        updateDropdownPosition();
         setOpen(true);
       }
     };
@@ -87,7 +103,6 @@ export const ScaleSelector = connectToWebSocket(
         return;
       }
       if (dropdownRef.current) {
-        dropdownRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         dropdownRef.current.focus();
       }
     }, [open, connected]);
@@ -107,7 +122,7 @@ export const ScaleSelector = connectToWebSocket(
         </button>
         {open ? (
           <ul
-            class={classes.dropDown}
+            class={classNames(classes.dropDown, dropdownOnTop && classes.onTop)}
             ref={dropdownRef}
             tabIndex={0}
             role="listbox"

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
@@ -40,7 +40,7 @@ export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale
         event.preventDefault();
         break;
       case 'ArrowUp':
-        setSelected((Math.max(selected, 0) + availableScales.length - 1) % availableScales.length);
+        setSelected(unsignedModulo(Math.max(selected, 0) - 1, availableScales.length));
         event.preventDefault();
         break;
       case 'Home':
@@ -126,3 +126,8 @@ export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale
     </div>
   );
 });
+
+// Unfortunately, the % operator in JavaScript is not a true modulo operator.
+// This works for arbitrary dividends even though dividends >= -1 would be sufficient
+const unsignedModulo = (dividend: number, divisor: number) =>
+  ((dividend % divisor) + divisor) % divisor;

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
@@ -44,11 +44,13 @@ export const ScaleSelector = connectToWebSocket(
     const handleKeyboardNavigation = (event: KeyboardEvent) => {
       switch (event.code) {
         case 'ArrowDown':
-          setSelected((selected + 1) % availableScales.length);
+          setSelected((selected) => (selected + 1) % availableScales.length);
           event.preventDefault();
           break;
         case 'ArrowUp':
-          setSelected(unsignedModulo(Math.max(selected, 0) - 1, availableScales.length));
+          setSelected((selected) =>
+            unsignedModulo(Math.max(selected, 0) - 1, availableScales.length)
+          );
           event.preventDefault();
           break;
         case 'Home':

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
@@ -1,25 +1,80 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { ScaleName, SCALES } from '../../../../shared/scales';
 import { SELECT_CHANGE_SCALE } from '../../constants';
+import sharedClasses from '../../styles.module.css';
 import { connectToWebSocket } from '../WebSocket/WebSocket';
 import classes from './ScaleSelector.module.css';
 
-export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale } }) => (
-  <select
-    disabled={!connected}
-    name="scale"
-    class={classes.select}
-    onChange={({ target }) =>
-      setScale(SCALES[(target as HTMLSelectElement).value as ScaleName].values)
+export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale } }) => {
+  const [open, setOpen] = useState(false);
+  const toggle = () => {
+    setOpen(!open);
+  };
+  const scaleSelectorRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    if (!connected) {
+      setOpen(false);
+      return;
     }
-    value={'CHANGE_SCALE'}
-  >
-    <option value="CHANGE_SCALE" selected disabled hidden>
-      {SELECT_CHANGE_SCALE}
-    </option>
-    {Object.entries(SCALES).map(([id, { name }]) => (
-      <option value={id} key={id}>
-        {name}
-      </option>
-    ))}
-  </select>
-));
+    if (dropdownRef.current) {
+      dropdownRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    const handleDocumentClick = (event: MouseEvent) => {
+      if (
+        scaleSelectorRef.current &&
+        event.target instanceof HTMLElement &&
+        !isChildNode(event.target, scaleSelectorRef.current)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', handleDocumentClick, true);
+    return () => {
+      document.removeEventListener('click', handleDocumentClick, true);
+    };
+  }, [open, connected]);
+
+  return (
+    <div class={classes.scaleSelector} ref={scaleSelectorRef}>
+      <button disabled={!connected} onClick={toggle} class={sharedClasses.button}>
+        {SELECT_CHANGE_SCALE}
+      </button>
+      {open ? (
+        <ul class={classes.dropDown} ref={dropdownRef}>
+          {Object.entries(SCALES).map(([id, { name }]) => (
+            <li
+              class={classes.dropDownItem}
+              key={id}
+              onClick={() => {
+                toggle();
+                setScale(SCALES[id as ScaleName].values);
+              }}
+            >
+              {name}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+});
+
+function isChildNode(child: HTMLElement | null, ancestor: HTMLElement): boolean {
+  if (!child) {
+    return false;
+  }
+  if (child === ancestor) {
+    return true;
+  }
+  let element: ParentNode | null = child;
+  while ((element = element.parentNode)) {
+    if (element === ancestor) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
+import { CardValue } from '../../../../shared/cards';
 import { ScaleName, SCALES } from '../../../../shared/scales';
 import { SELECT_CHANGE_SCALE } from '../../constants';
 import sharedClasses from '../../styles.module.css';
@@ -7,127 +8,141 @@ import classes from './ScaleSelector.module.css';
 
 const availableScales = Object.entries(SCALES);
 
-export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale } }) => {
-  const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(-1);
-  const selectionButtonRef = useRef<HTMLButtonElement>(null);
-  const dropdownRef = useRef<HTMLUListElement>(null);
+export const ScaleSelector = connectToWebSocket(
+  ({
+    socket: {
+      connected,
+      setScale,
+      state: { scale },
+    },
+  }) => {
+    const [open, setOpen] = useState(false);
+    const [selected, setSelected] = useState(-1);
+    const selectionButtonRef = useRef<HTMLButtonElement>(null);
+    const dropdownRef = useRef<HTMLUListElement>(null);
 
-  const close = () => {
-    setOpen(false);
-    setSelected(-1);
-  };
+    const close = () => {
+      setOpen(false);
+      setSelected(-1);
+    };
 
-  const toggle = () => {
-    if (open) {
-      close();
-    } else {
-      setSelected(0);
-      setOpen(true);
-    }
-  };
-
-  const handleBlur = ({ relatedTarget }: FocusEvent) => {
-    if (relatedTarget !== selectionButtonRef.current && relatedTarget !== dropdownRef.current) {
-      close();
-    }
-  };
-
-  const handleKeyboardNavigation = (event: KeyboardEvent) => {
-    switch (event.code) {
-      case 'ArrowDown':
-        setSelected((selected + 1) % availableScales.length);
-        event.preventDefault();
-        break;
-      case 'ArrowUp':
-        setSelected(unsignedModulo(Math.max(selected, 0) - 1, availableScales.length));
-        event.preventDefault();
-        break;
-      case 'Home':
-      case 'PageUp':
-        setSelected(0);
-        break;
-      case 'End':
-      case 'PageDown':
-        setSelected(availableScales.length - 1);
-        break;
-      case 'Escape':
+    const toggle = () => {
+      if (open) {
         close();
-        selectionButtonRef.current?.focus();
-        break;
-      case 'Enter':
-      case 'Space':
-        // Prevent "enter" from triggering the button if the dropdown is open
-        event.preventDefault();
+      } else {
+        setSelected(availableScales.findIndex(isScaleSelected(scale)) || 0);
+        setOpen(true);
+      }
+    };
+
+    const handleBlur = ({ relatedTarget }: FocusEvent) => {
+      if (relatedTarget !== selectionButtonRef.current && relatedTarget !== dropdownRef.current) {
         close();
-        selectionButtonRef.current?.focus();
-        if (selected >= 0) {
-          setScale(availableScales[selected][1].values);
-        }
-        break;
-    }
-  };
+      }
+    };
 
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    if (!connected) {
-      close();
-      return;
-    }
-    if (dropdownRef.current) {
-      dropdownRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      dropdownRef.current.focus();
-    }
-  }, [open, connected]);
+    const handleKeyboardNavigation = (event: KeyboardEvent) => {
+      switch (event.code) {
+        case 'ArrowDown':
+          setSelected((selected + 1) % availableScales.length);
+          event.preventDefault();
+          break;
+        case 'ArrowUp':
+          setSelected(unsignedModulo(Math.max(selected, 0) - 1, availableScales.length));
+          event.preventDefault();
+          break;
+        case 'Home':
+        case 'PageUp':
+          setSelected(0);
+          break;
+        case 'End':
+        case 'PageDown':
+          setSelected(availableScales.length - 1);
+          break;
+        case 'Escape':
+          close();
+          selectionButtonRef.current?.focus();
+          break;
+        case 'Enter':
+        case 'Space':
+          // Prevent "enter" from triggering the button if the dropdown is open
+          event.preventDefault();
+          close();
+          selectionButtonRef.current?.focus();
+          if (selected >= 0) {
+            setScale(availableScales[selected][1].values);
+          }
+          break;
+      }
+    };
 
-  return (
-    <div class={classes.scaleSelector}>
-      <button
-        disabled={!connected}
-        onClick={toggle}
-        class={sharedClasses.button}
-        ref={selectionButtonRef}
-        onBlur={handleBlur}
-        aria-expanded={open}
-        aria-haspopup="listbox"
-      >
-        {SELECT_CHANGE_SCALE}
-      </button>
-      {open ? (
-        <ul
-          class={classes.dropDown}
-          ref={dropdownRef}
-          tabIndex={0}
-          role="listbox"
-          aria-label="scales"
+    useEffect(() => {
+      if (!open) {
+        return;
+      }
+      if (!connected) {
+        close();
+        return;
+      }
+      if (dropdownRef.current) {
+        dropdownRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        dropdownRef.current.focus();
+      }
+    }, [open, connected]);
+
+    return (
+      <div class={classes.scaleSelector}>
+        <button
+          disabled={!connected}
+          onClick={toggle}
+          class={sharedClasses.button}
+          ref={selectionButtonRef}
           onBlur={handleBlur}
-          onKeyDown={handleKeyboardNavigation}
+          aria-expanded={open}
+          aria-haspopup="listbox"
         >
-          {availableScales.map(([id, { name }], index) => (
-            <li
-              class={classes.dropDownItem}
-              key={id}
-              role="option"
-              aria-selected={selected === index}
-              onClick={() => {
-                close();
-                setScale(SCALES[id as ScaleName].values);
-              }}
-              onMouseMove={() => selected !== index && setSelected(index)}
-              onMouseLeave={() => selected === index && setSelected(-1)}
-            >
-              {name}
-            </li>
-          ))}
-        </ul>
-      ) : null}
-    </div>
-  );
-});
+          {SELECT_CHANGE_SCALE}
+        </button>
+        {open ? (
+          <ul
+            class={classes.dropDown}
+            ref={dropdownRef}
+            tabIndex={0}
+            role="listbox"
+            aria-label="scales"
+            onBlur={handleBlur}
+            onKeyDown={handleKeyboardNavigation}
+          >
+            {availableScales.map(([id, { name }], index) => (
+              <li
+                class={classes.dropDownItem}
+                key={id}
+                role="option"
+                aria-selected={selected === index}
+                onClick={() => {
+                  close();
+                  setScale(SCALES[id as ScaleName].values);
+                }}
+                onMouseMove={() => selected !== index && setSelected(index)}
+                onMouseLeave={() => selected === index && setSelected(-1)}
+              >
+                {name}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    );
+  }
+);
 
 // Unfortunately, the % operator in JavaScript is not a true modulo operator.
-// This works for arbitrary dividends even though dividends >= -1 would be sufficient
+// The helper below works for arbitrary dividends even though >= -1 would be sufficient
 const unsignedModulo = (dividend: number, divisor: number) =>
   ((dividend % divisor) + divisor) % divisor;
+
+const isScaleSelected =
+  (currentScale: CardValue[]) =>
+  ([, { values }]: typeof availableScales[number]) =>
+    values.length === currentScale.length &&
+    values.every((value, index) => value === currentScale[index]);

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
@@ -85,6 +85,7 @@ export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale
           ref={dropdownRef}
           tabIndex={0}
           role="listbox"
+          aria-label="scales"
           onBlur={handleBlur}
           onKeyDown={handleKeyboardNavigation}
         >

--- a/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/Components/ScaleSelector/ScaleSelector.tsx
@@ -5,54 +5,101 @@ import sharedClasses from '../../styles.module.css';
 import { connectToWebSocket } from '../WebSocket/WebSocket';
 import classes from './ScaleSelector.module.css';
 
+const availableScales = Object.entries(SCALES);
+
 export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale } }) => {
   const [open, setOpen] = useState(false);
-  const toggle = () => {
-    setOpen(!open);
-  };
-  const scaleSelectorRef = useRef<HTMLDivElement>(null);
+  const [selected, setSelected] = useState(-1);
+  const selectionButtonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLUListElement>(null);
+
+  const close = () => {
+    setOpen(false);
+    setSelected(-1);
+  };
+
+  const toggle = () => {
+    if (open) {
+      close();
+    } else {
+      setOpen(true);
+    }
+  };
+
+  const handleBlur = ({ relatedTarget }: FocusEvent) => {
+    if (relatedTarget !== selectionButtonRef.current && relatedTarget !== dropdownRef.current) {
+      close();
+    }
+  };
+
+  const handleKeyboardNavigation = (event: KeyboardEvent) => {
+    switch (event.key) {
+      case 'ArrowDown':
+        setSelected((selected + 1) % availableScales.length);
+        event.preventDefault();
+        break;
+      case 'ArrowUp':
+        setSelected((Math.max(selected, 0) + availableScales.length - 1) % availableScales.length);
+        event.preventDefault();
+        break;
+      case 'Enter':
+      case ' ':
+        // Prevent "enter" from triggering the button if the dropdown is open
+        event.preventDefault();
+        if (selected >= 0) {
+          close();
+          setScale(availableScales[selected][1].values);
+          selectionButtonRef.current?.focus();
+        }
+    }
+  };
 
   useEffect(() => {
     if (!open) return;
     if (!connected) {
-      setOpen(false);
+      close();
       return;
     }
     if (dropdownRef.current) {
       dropdownRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      dropdownRef.current.focus();
     }
-
-    const handleDocumentClick = (event: MouseEvent) => {
-      if (
-        scaleSelectorRef.current &&
-        event.target instanceof HTMLElement &&
-        !isChildNode(event.target, scaleSelectorRef.current)
-      ) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('click', handleDocumentClick, true);
-    return () => {
-      document.removeEventListener('click', handleDocumentClick, true);
-    };
   }, [open, connected]);
 
   return (
-    <div class={classes.scaleSelector} ref={scaleSelectorRef}>
-      <button disabled={!connected} onClick={toggle} class={sharedClasses.button}>
+    <div class={classes.scaleSelector}>
+      <button
+        disabled={!connected}
+        onClick={toggle}
+        class={sharedClasses.button}
+        ref={selectionButtonRef}
+        onBlur={handleBlur}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
         {SELECT_CHANGE_SCALE}
       </button>
       {open ? (
-        <ul class={classes.dropDown} ref={dropdownRef}>
-          {Object.entries(SCALES).map(([id, { name }]) => (
+        <ul
+          class={classes.dropDown}
+          ref={dropdownRef}
+          tabIndex={0}
+          role="listbox"
+          onBlur={handleBlur}
+          onKeyDown={handleKeyboardNavigation}
+        >
+          {availableScales.map(([id, { name }], index) => (
             <li
               class={classes.dropDownItem}
               key={id}
+              role="option"
+              aria-selected={selected === index}
               onClick={() => {
-                toggle();
+                close();
                 setScale(SCALES[id as ScaleName].values);
               }}
+              onMouseMove={() => selected !== index && setSelected(index)}
+              onMouseLeave={() => selected === index && setSelected(-1)}
             >
               {name}
             </li>
@@ -62,19 +109,3 @@ export const ScaleSelector = connectToWebSocket(({ socket: { connected, setScale
     </div>
   );
 });
-
-function isChildNode(child: HTMLElement | null, ancestor: HTMLElement): boolean {
-  if (!child) {
-    return false;
-  }
-  if (child === ancestor) {
-    return true;
-  }
-  let element: ParentNode | null = child;
-  while ((element = element.parentNode)) {
-    if (element === ancestor) {
-      return true;
-    }
-  }
-  return false;
-}

--- a/frontend/src/test-helpers/renderWithWebSocket.tsx
+++ b/frontend/src/test-helpers/renderWithWebSocket.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/preact';
+import { render, RenderResult } from '@testing-library/preact';
 import { ComponentChildren } from 'preact';
 import { SCALES } from '../../../shared/scales';
 import { WebSocketContext } from '../Components/WebSocket/WebSocket';
@@ -41,7 +41,7 @@ export const getRenderWithWebSocket =
       <WebSocketContext.Provider value={getApi(defaultApi, api)}>
         {children}
       </WebSocketContext.Provider>
-    );
+    ) as RenderResult & { container: HTMLElement };
     return {
       ...rendered,
       rerender(apiUpdate: PartialWebsocketApi = {}) {

--- a/frontend/src/test-helpers/renderWithWebSocket.tsx
+++ b/frontend/src/test-helpers/renderWithWebSocket.tsx
@@ -1,4 +1,4 @@
-import { render, RenderResult } from '@testing-library/preact';
+import { render } from '@testing-library/preact';
 import { ComponentChildren } from 'preact';
 import { SCALES } from '../../../shared/scales';
 import { WebSocketContext } from '../Components/WebSocket/WebSocket';
@@ -41,7 +41,7 @@ export const getRenderWithWebSocket =
       <WebSocketContext.Provider value={getApi(defaultApi, api)}>
         {children}
       </WebSocketContext.Provider>
-    ) as RenderResult & { container: HTMLElement };
+    );
     return {
       ...rendered,
       rerender(apiUpdate: PartialWebsocketApi = {}) {


### PR DESCRIPTION
- Resolves #103 

Motivated by issues with the different ways select elements are handled across browsers, this implements a custom dropdown element. Admittedly I thought this was straightforward, but there is indeed some hidden complexity involved. This implementation should be fully ARIA-compliant, as using attributes like `aria-selected` also proved helpful in writing tests.
It supports both mouse and keyboard navigation. To avoid the double selection highlight one sees in some implementation (one for keyboard, one for mouse hover), I took some inspiration from the native MacOS dropdown. Here, you can use arrow keys to move the selection but when the mouse is moved, it "steals" the selection. Hitting enter then selects whatever is currently highlighted either through mouse or keyboard.
To close the dropdown via mouse click, I made the dropdown itself focusable. When the dropdown loses focus, then this also closes the dropdown. More precisely, when the dropdown is opened it is also focused, but it will only stay open as long as either the button or the dropdown is focused. Including the button focus was necessary to avoid issues when the user clicks the button to close the dropdown.

This is what is looks like:
<img width="307" alt="scale-selector" src="https://user-images.githubusercontent.com/12949268/229602143-e0c02581-5831-4fc4-8e12-1f6ea4d31535.png">
For simplicity, it always opens to the bottom, scrolling into view if necessary.

I created a comprehensive unit test suite as well as an E2E test.