### PR TITLE
Add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":gitSignOff"],
+  "dependencyDashboard": true,
+  "configMigration": true,
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "lockFileMaintenance"],
+      "groupName": "minor/patch updates",
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["node", "npm"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["@types/node"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    }
+  ],
+  "automergeType": "pr",
+  "platformCommit": true,
+  "internalChecksFilter": "strict",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am on Friday"]
+  },
+  "minimumReleaseAge": "3 days",
+  "schedule": ["before 4am on Friday"]
+}


### PR DESCRIPTION
This will add a basic config for renovate. It should create a merge request every Friday morning with all minor and path updates that with a little luck will also be auto-merged.
Other (major) updates will receive separate PRs.