### PR TITLE
Ignore special keyboard events

### DIFF
--- a/frontend/src/Components/CardSelector/CardSelector.test.tsx
+++ b/frontend/src/Components/CardSelector/CardSelector.test.tsx
@@ -231,4 +231,23 @@ describe('The CardSelector', () => {
     // then
     expect(setVote).toHaveBeenNthCalledWith(2, 'S');
   });
+
+  it.each`
+    description | event
+    ${'Ctrl'}   | ${{ key: '1', ctrlKey: true }}
+    ${'Alt'}    | ${{ key: '1', altKey: true }}
+    ${'Meta'}   | ${{ key: '1', metaKey: true }}
+  `('ignores "$description" events', ({ event }) => {
+    const setVote = vi.fn();
+    render({
+      setVote,
+      state: { votes: { TheUser: VOTE_NOTE_VOTED, OtherUser: '5' } },
+    });
+
+    // when
+    fireEvent.keyDown(window, event);
+
+    // then
+    expect(setVote).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/Components/CardSelector/CardSelector.tsx
+++ b/frontend/src/Components/CardSelector/CardSelector.tsx
@@ -46,7 +46,12 @@ export const CardSelector = connectToWebSocket(
   ({ socket: { connected, loginData, setVote, state } }) => {
     const selectedCard = state.votes[loginData.user];
 
-    const onKeyDown = ({ key }: KeyboardEvent) => {
+    const onKeyDown = ({ key, ctrlKey, altKey, metaKey }: KeyboardEvent) => {
+      // We don't check for 'shiftKey' because it is used for the question mark
+      if (ctrlKey || altKey || metaKey) {
+        return;
+      }
+
       const matchingCards = state.scale.filter(
         (card) => card[0].toLowerCase() === key.toLowerCase(),
       );


### PR DESCRIPTION
* Some special keyboard events are used by other applications (e.g. the browser). Such events are always a key combination involving "Ctrl", "Shift", "Alt" or "Meta" (the "Windows Key" on windows computers). For example, many browsers use the shortcut "Ctrl+N" to navigate to the Nth tab
* This PR disables keyboard navigation for special events
* The only exception are "Shift" events, since they are used for some special cards (such as the question mark)